### PR TITLE
ログイン後ヘッダーのレイアウト調整

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,20 +17,62 @@
     </div>
 
     <!-- ナビゲーション -->
-    <nav class="flex items-center gap-3 text-xs md:text-sm">
+    <nav class="flex items-center gap-2 md:gap-3 text-xs md:text-sm">
       <% if user_signed_in? %>
-        <!-- ログイン後ナビ -->
-        <%= link_to "マイページ",
-              mypage_path,
-              class: "inline-flex items-center justify-center rounded-full
-                       px-3 py-1.5 md:px-4 md:py-2 font-semibold
-                       text-amber-50 bg-amber-700 hover:bg-amber-800 transition" %>
+      <!-- ログイン後ナビ -->
+        <%= link_to "コーヒーを記録",
+            new_coffee_log_path,
+            class: "inline-flex items-center justify-center rounded-full
+                    px-3 py-1.5 md:px-4 md:py-2 font-semibold
+                    text-amber-50 bg-amber-700 hover:bg-amber-800 transition" %>
+        <!-- md以上ではフルナビ、モバイルはメニューに格納 -->
+        <div class="hidden md:flex items-center gap-3">
+          <%= link_to "記録一覧",
+                coffee_logs_path,
+                class: "text-stone-700 hover:text-stone-900 px-2 py-1" %>
 
-        <%= button_to "ログアウト",
-              destroy_user_session_path,
-              method: :delete,
-              form: { data: { turbo: false } },
-              class: "text-stone-600 hover:text-stone-900 px-2 py-1" %>
+          <%= link_to "あなたの傾向",
+                preferences_path,
+                class: "text-stone-700 hover:text-stone-900 px-2 py-1" %>
+
+          <%= link_to "マイページ",
+                mypage_path,
+                class: "text-stone-700 hover:text-stone-900 px-2 py-1" %>
+
+          <%= button_to "ログアウト",
+                destroy_user_session_path,
+                method: :delete,
+                form: { data: { turbo: false } },
+                class: "text-stone-600 hover:text-stone-900 px-2 py-1 cursor-pointer" %>
+        </div>
+        <!-- モバイル用メニュー（JS不要） -->
+        <details class="md:hidden relative">
+          <summary class="list-none inline-flex items-center justify-center rounded-full px-3 py-1.5 font-semibold border border-stone-300 text-stone-700 hover:bg-stone-50 transition cursor-pointer">
+            メニュー
+          </summary>
+
+          <div class="absolute right-0 mt-2 w-44 rounded-xl border bg-white shadow-lg p-2 z-50">
+            <%= link_to "マイページ",
+                  mypage_path,
+                  class: "block px-3 py-2 rounded-lg text-sm text-stone-700 hover:bg-stone-50" %>
+
+            <%= link_to "記録一覧",
+                  coffee_logs_path,
+                  class: "block px-3 py-2 rounded-lg text-sm text-stone-700 hover:bg-stone-50" %>
+
+            <%= link_to "あなたの傾向",
+                  preferences_path,
+                  class: "block px-3 py-2 rounded-lg text-sm text-stone-700 hover:bg-stone-50" %>
+
+            <div class="my-1 border-t"></div>
+
+            <%= button_to "ログアウト",
+                  destroy_user_session_path,
+                  method: :delete,
+                  form: { data: { turbo: false } },
+                  class: "w-full text-left px-3 py-2 rounded-lg text-sm text-stone-700 hover:bg-stone-50 cursor-pointer" %>
+          </div>
+        </details>
       <% else %>
         <!-- ログイン前ナビ -->
         <%= link_to "このアプリについて",


### PR DESCRIPTION
### ログイン後ヘッダーのレイアウト調整
以下の通り調整
#### 常時表示
- コーヒーを記録
#### モバイル時にメニューに格納
- マイページ
- 記録一覧
- 記録の傾向
- ログアウト