### PR TITLE
fix: モバイルファーストのデザイン調整

### DIFF
--- a/app/controllers/taste_diagnoses_controller.rb
+++ b/app/controllers/taste_diagnoses_controller.rb
@@ -4,7 +4,7 @@ class TasteDiagnosesController < ApplicationController
   TASTE_QUESTIONS = [
     {
       key: :chocolate,
-      title: "チョコレートを買うとき、どちらを選ぶ事が多いですか？",
+      title: "チョコレートを買うとき、最も選ぶのが多いのは？",
       options: [
         { label: "甘めのミルクチョコレート", value: "milk_chocolate" },
         { label: "ビターなダークチョコレート", value: "dark_chocolate"  },
@@ -13,7 +13,7 @@ class TasteDiagnosesController < ApplicationController
     },
     {
       key: :cake,
-      title: "次の中で、コーヒーと合わせて食べたいと思うケーキはどれですか？",
+      title: "次の中で、コーヒーと合わせて食べたいと思うケーキは？",
       options: [
         { label: "フルーツタルト", value: "fruit_tart" },
         { label: "モンブラン", value: "mont_blanc"  },
@@ -22,7 +22,7 @@ class TasteDiagnosesController < ApplicationController
     },
     {
       key: :dressing,
-      title: "サラダにドレッシングをかけるなら、次のうちどれが最も多いですか？",
+      title: "以下のサラダのドレッシングで最も好きなのは？",
       options: [
         { label: "フレンチドレッシング", value: "french_dressing" },
         { label: "和風しょうゆドレッシング",     value: "japanese_dressing"      },
@@ -31,7 +31,7 @@ class TasteDiagnosesController < ApplicationController
     },
     {
       key: :amount,
-      title: "コーヒーを飲むとき、以下のどちらの飲み方の方が好みですか？",
+      title: "コーヒーを飲むときは、どちらの飲み方の方が好み？",
       options: [
         { label: "あっさりめの濃さ を たっぷりめの量 で飲みたい", value: "much" },
         { label: "どっしりめの濃さ を 控えめの量 で飲みたい",     value: "little"      },
@@ -40,11 +40,11 @@ class TasteDiagnosesController < ApplicationController
     },
     {
       key: :dislike,
-      title: "以下のうち、食べるのをイメージしてより「苦手だ」と感じるのはどちらですか？",
+      title: "以下をイメージして、より「苦手だ」と感じるのは？",
       options: [
         { label: "酸っぱいレモン", value: "too_sour" },
         { label: "カカオ95%以上のとても苦いチョコレート",     value: "too_bitter"      },
-        { label: "わからない、もしくは どちらも苦手ではない", value: "both_like"          }
+        { label: "わからない / どちらも苦手ではない", value: "both_like"          }
       ]
     }
   ].freeze

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,11 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import Chartkick from "chartkick"
 import "chartkick/chart.js"
+
+document.addEventListener("turbo:load", () => {
+  setTimeout(() => {
+    Chartkick.eachChart((chart) => chart.redraw())
+  }, 0)
+})

--- a/app/services/recommended_roast.rb
+++ b/app/services/recommended_roast.rb
@@ -14,7 +14,7 @@ class RecommendedRoast
       return build(
         roast_key: @liked[:summary_roast_key],
         label: @liked[:summary_roast],
-        reason: "★4以上の評価が最も多い",
+        reason: "★4以上が最も多い",
         n: @liked[:logs_count],
         message: "最近の「好き」から見ると、この焙煎度が合いやすいです。"
       )
@@ -38,7 +38,7 @@ class RecommendedRoast
       return build(
         roast_key: key,
         label: label,
-        reason: "味覚診断ベース（記録が少ないため）",
+        reason: "味覚診断ベース",
         n: 0,
         message: "まずは診断結果の焙煎度を軸に選んで、記録を増やしてみましょう。"
       )

--- a/app/views/coffee_logs/index.html.erb
+++ b/app/views/coffee_logs/index.html.erb
@@ -4,15 +4,15 @@
     <%= link_to "新規記録", new_coffee_log_path,
                 class: "inline-flex items-center px-4 py-2 rounded-full text-sm font-semibold bg-amber-700 text-white hover:bg-amber-800 transition" %>
   </div>
-  <%= form_with url: coffee_logs_path, method: :get, local: true, class: "flex gap-2 items-center" do |f| %>
+  <%= form_with url: coffee_logs_path, method: :get, local: true, class: "flex flex-col sm:flex-row gap-2 sm:items-center" do |f| %>
     <%= f.text_field :q,
         value: params[:q],
         placeholder: "商品名 / 店名 / メモで検索",
-        class: "flex-1 rounded border px-3 py-2" %>
+        class: "w-full sm:flex-1 min:w-0 rounded border px-3 py-2" %>
     <%= f.submit "検索",
-        class: "shrink-0 px-4 py-2 rounded bg-amber-700 text-white hover:bg-amber-800 transition" %>
+        class: "flex-1 sm:flex-none px-4 py-2 rounded bg-amber-700 text-white hover:bg-amber-800 transition" %>
     <% if params[:q].present? %>
-      <%= link_to "クリア", coffee_logs_path, class: "shrink-0 px-4 py-2 rounded border hover:bg-gray-50 transition" %>
+      <%= link_to "クリア", coffee_logs_path, class: "flex-1 sm:flex-none px-4 py-2 rounded border hover:bg-gray-50 transition text-center" %>
     <% end %>
   <% end %>
   <% if @coffee_logs.any? %>
@@ -23,23 +23,33 @@
             <p class="text-sm text-gray-500">
               <%= log.drank_on %> / <%= log.place_cafe? ? "お店" : (log.place_home? ? "自宅" : "その他") %>
               <% if log.place_cafe? && log.cafe_name.present? %>
-                ・<%= log.cafe_name %>
+                (<%= log.cafe_name %>)
               <% end %>
             </p>
             <p class="font-semibold text-gray-900 truncate">
               <%= log.coffee_name.presence || "（商品名未入力）" %>
             </p>
-            <p class="text-sm text-gray-700 mt-1">
-              焙煎度：<%= log.roast_level %> /
-              酸味：<%= ["弱い", "普通", "強い"][log.acidity] %> /
-              苦み：<%= ["弱い", "普通", "強い"][log.bitterness] %> /
-              好み度：<%= "★" * log.overall_rating %>
-            </p>
+            <div class="mt-2 flex flex-wrap gap-2 text-xs">
+              <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                焙煎度：<%= log.roast_level %>
+              </span>
+              <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                酸味：<%= ["弱い", "普通", "強い"][log.acidity] %>
+              </span>
+              <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                苦み：<%= ["弱い", "普通", "強い"][log.bitterness] %>
+              </span>
+              <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                好み度：<%= "★" * log.overall_rating %>
+              </span>
+            </div>
+
             <% if log.memo.present? %>
               <p class="text-sm text-gray-600 mt-1 line-clamp-2"><%= log.memo %></p>
             <% end %>
           </div>
-          <div class="shrink-0 flex items-center gap-2">
+          <div class="shrink-0 flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+
             <%= link_to "詳細", coffee_log_path(log), class: "px-3 py-2 rounded border text-sm hover:bg-gray-50" %>
             <%= link_to "編集", edit_coffee_log_path(log), class: "px-3 py-2 rounded border text-sm hover:bg-gray-50" %>
           </div>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -33,7 +33,7 @@
   <!-- おすすめ焙煎度（結論は1つだけ） -->
   <section class="bg-white rounded-xl shadow-sm p-6">
     <div class="flex items-center justify-between mb-2">
-      <h2 class="text-lg font-semibold">あなたにおすすめの焙煎度</h2>
+      <h2 class="text-lg font-semibold">おすすめ</h2>
       <% if @recommended_roast&.dig(:available) %>
         <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-800">
           <%= @recommended_roast[:reason] %>
@@ -104,21 +104,18 @@
   
   <!-- コーヒーの傾向（簡易表示） -->
   <section class="bg-white rounded-xl shadow-sm p-6">
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
-      <h2 class="text-lg font-semibold">記録からみた傾向（参考）</h2>
+    <div class="flex items-center sm:justify-between gap-3 mb-4">
+      <h2 class="text-lg font-semibold min-w-0">記録からみた傾向</h2>
       <%= link_to "詳細へ",
                   preferences_path,
-                  class: "inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold border border-gray-300 text-gray-700 hover:bg-gray-50 transition" %>
+                  class: "shrink-0 inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold border border-gray-300 text-gray-700 hover:bg-gray-50 transition" %>
     </div>
   
     <div class="grid md:grid-cols-2 gap-4">
       <!-- （全記録） -->
-      <div class="rounded-lg border p-4 space-y-2">
-        <div class="flex items-center justify-between">
-          <p class="text-sm font-semibold text-gray-900">全ての記録</p>
-          <%= link_to "詳しく",
-                      preferences_path(scope: "all"),
-                      class: "text-xs text-gray-600 hover:underline" %>
+      <div class="rounded-lg border p-4 space-y-2 min-w-0">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-sm font-semibold text-gray-900 min-w-0">全ての記録</p>
         </div>
 
         <% if @preference_all[:available] %>
@@ -129,11 +126,16 @@
             対象：<%= @preference_all[:logs_count] %>件（件数ベース）
           </p>
 
-          <div class="mt-2">
-            <%= pie_chart @preference_all[:roast_pie], donut: true, height: "160px", legend: false %>
+          <div class="mt-2 w-full overflow-hidden min-w-0">
+            <%= pie_chart @preference_all[:roast_pie], 
+                  donut: true, 
+                  height: "180px", 
+                  width: "100%", 
+                  legend: false, 
+                  library: { responsive: true, maintainAspectRatio: false } %>
           </div>
         <% else %>
-          <p class="text-sm text-gray-600">
+          <p class="text-sm text-gray-600 leading-relaxed">
             まだ傾向を表示できる記録がありません。
           </p>
           <%= link_to "記録する",
@@ -143,12 +145,9 @@
       </div>
 
       <!-- 好き（★4以上） -->
-      <div class="rounded-lg border p-4 space-y-2">
-        <div class="flex items-center justify-between">
-          <p class="text-sm font-semibold text-gray-900">好評価(★4以上)</p>
-          <%= link_to "詳しく",
-                      preferences_path(scope: "liked"),
-                      class: "text-xs text-gray-600 hover:underline" %>
+      <div class="rounded-lg border p-4 space-y-2 min-w-0">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-sm font-semibold text-gray-900 min-w-0">好評価(★4以上)</p>
         </div>
 
         <% if @preference_liked[:available] %>
@@ -158,29 +157,34 @@
           <p class="text-xs text-gray-500">
             対象：<%= @preference_liked[:logs_count] %>件（件数ベース）
           </p>
-          <div class="mt-2">
-            <%= pie_chart @preference_liked[:roast_pie], donut: true, height: "160px", legend: false %>
+          <div class="mt-2 w-full overflow-hidden min-w-0">
+            <%= pie_chart @preference_liked[:roast_pie], 
+            donut: true, 
+            height: "160px", 
+            width: "100%", 
+            legend: false,
+            library: { responsive: true, maintainAspectRatio: false } %>
           </div>
         <% else %>
-          <p class="text-sm text-gray-600">
+          <p class="text-sm text-gray-600 leading-relaxed">
             ★4以上の記録がまだありません。お気に入りに★4以上を付けると「好き」が見えてきます。
           </p>
         <% end %>
       </div>
     </div>
 
-    <%# 信頼度メッセージ（全期間ベースなので all 側の notice を使うのが自然） %>
+    <%# 補足メッセージ %>
     <% if @preference_all[:available] %>
-      <p class="text-xs text-gray-500 mt-4">
+      <p class="text-xs text-gray-500 mt-4 leading-relaxed">
         <%= @preference_all[:notice] %>
       </p>
     <% end %>
   </section>
 
-  <!-- コーヒー記録エリア（MVP向けに枠だけ用意） -->
+  <!-- コーヒー記録エリア -->
   <section class="bg-white rounded-xl shadow-sm p-6">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold">コーヒー記録</h2>
+      <h2 class="text-lg font-semibold">最近の記録</h2>
       <div class="flex gap-2">
         <%= link_to "記録一覧",
                     coffee_logs_path,
@@ -212,19 +216,21 @@
                   <%= log.coffee_name.presence || "（商品名未入力）" %>
                 </p>
 
-                <p class="text-sm text-gray-700 mt-2">
-                  酸味：<%= ["弱い", "普通", "強い"][log.acidity] %>
-                  ・苦み：<%= ["弱い", "普通", "強い"][log.bitterness] %>
-                  ・好み度：<%= "★" * log.overall_rating %>
-                </p>
+                <div class="mt-2 flex flex-wrap gap-2 text-xs">
+                  <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                    酸味：<%= ["弱い", "普通", "強い"][log.acidity] %>
+                  </span>
+                  <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                    苦み：<%= ["弱い", "普通", "強い"][log.bitterness] %>
+                  </span>
+                  <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-700">
+                    好み度：<%= "★" * log.overall_rating %>
+                  </span>
+                </div>
 
                 <% if log.memo.present? %>
                   <p class="text-sm text-gray-600 mt-2 line-clamp-2"><%= log.memo %></p>
                 <% end %>
-              </div>
-
-              <div class="shrink-0 text-xs text-gray-500">
-                詳細 →
               </div>
             </div>
           <% end %>

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -40,17 +40,17 @@
 
     <div class="grid md:grid-cols-2 gap-6">
       <!-- 焙煎度（円グラフ） -->
-      <div class="rounded-xl border bg-white p-6 shadow-sm">
+      <div class="rounded-xl border bg-white p-6 shadow-sm wrapper w-full overflow-hidden">
         <h2 class="text-lg font-semibold mb-1">焙煎度の割合（件数）</h2>
         <p class="text-xs text-gray-500 mb-3"><%= @preference[:charts_reason] %></p>
-        <%= pie_chart @preference[:roast_pie], donut: true, legend: "bottom", height: "260px" %>
+        <%= pie_chart @preference[:roast_pie], donut: true, legend: "bottom", height: "260px", width: "100%", library: { responsive: true, maintainAspectRatio: false } %>
       </div>
 
       <!-- 味（棒グラフ） -->
-      <div class="rounded-xl border bg-white p-6 shadow-sm">
+      <div class="rounded-xl border bg-white p-6 shadow-sm wrapper w-full overflow-hidden">
         <h2 class="text-lg font-semibold mb-1">味の傾向（0〜10）</h2>
         <p class="text-xs text-gray-500 mb-3">選んだ記録の平均（件数ベース）です。</p>
-        <%= column_chart @preference[:taste_bar], min: 0, max: 10, height: "260px" %>
+        <%= column_chart @preference[:taste_bar], min: 0, max: 10, height: "260px", width: "100%", library: { responsive: true, maintainAspectRatio: false } %>
       </div>
     </div>
 

--- a/app/views/taste_diagnoses/new.html.erb
+++ b/app/views/taste_diagnoses/new.html.erb
@@ -5,7 +5,7 @@
     コーヒー味覚診断
   </h1>
 
-  <p class="text-sm text-gray-600 mb-8 text-center">
+  <p class="text-xs text-gray-700 mb-8 mt-1 text-center leading-relaxed">
     いくつかの質問に直感でお答えください。<br>
     あなたの「好きなコーヒーの傾向」を診断します。
   </p>


### PR DESCRIPTION
### モバイルファーストのデザイン調整
幅375px(iphone等の一般的な表示幅)を基準に各所を調整
- マイページ
- 味覚診断画面
- 味覚診断結果画面
- コーヒー記録一覧画面