### PR TITLE
add: 診断結果のXシェア機能追加

### DIFF
--- a/app/controllers/taste_diagnoses_controller.rb
+++ b/app/controllers/taste_diagnoses_controller.rb
@@ -203,6 +203,6 @@ class TasteDiagnosesController < ApplicationController
       end
     end
 
-  [ preferred_roast, taste_type, description ]
-end
+    [ preferred_roast, taste_type, description ]
+  end
 end

--- a/app/views/taste_profiles/show.html.erb
+++ b/app/views/taste_profiles/show.html.erb
@@ -4,6 +4,9 @@
 <% roast_label = t(".roast_label.#{roast_key}", default: t(".roast_label.default")) %>
 <% tagline = t(".tagline.#{roast_key}", default: t(".tagline.default")) %>
 <% roast_hint = t(".roast_hint.#{roast_key}", default: t(".roast_hint.default")) %>
+<% share_text = t(".share.text", tagline: tagline, roast: roast_label) %>
+<% share_url  = "https://twitter.com/intent/tweet?text=#{ERB::Util.url_encode(share_text)}&url=#{ERB::Util.url_encode(root_url)}" %>
+
 
 <div class="max-w-3xl mx-auto py-10 px-4">
   <h1 class="text-2xl font-semibold mb-6 text-center">
@@ -47,5 +50,9 @@
     <%= link_to t(".actions.back"),
                 mypage_path,
                 class: "px-4 py-2 rounded-full text-sm font-semibold border border-amber-700 text-white bg-amber-700 hover:bg-amber-800 text-center" %>
+    <%= link_to t(".actions.share_x"),
+                share_url,
+                target: "_blank", rel: "noopener",
+                class: "px-4 py-2 rounded-full text-sm font-semibold border border-gray-300 hover:bg-gray-50 text-center" %>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -105,6 +105,9 @@ ja:
       actions:
         retry: "もう一度診断する"
         back: "マイページへ戻る"
+        share_x: "診断結果をXでシェア"
+      share:
+        text: "TrueCupで味覚診断しました。私のタイプは「%{tagline}」（おすすめ：%{roast}） #TrueCup"
   mypage:
     show:
       greeting: "%{name}さん、こんにちは！"


### PR DESCRIPTION
### 味覚診断結果のSNSシェア機能
診断結果をXの投稿画面からシェアできるよう追加
- taste_profiles/show.html.erbにシェアリンクと共有テキストを定義してボタンを追加
- i18n(ja.yml)に追加