### PR TITLE
feat: 初回ユーザー向けオンボーディングモーダルを実装 (#83)

### DIFF
--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,0 +1,6 @@
+class OnboardingsController < ApplicationController
+  def complete
+    current_user.update!(onboarding_completed: true)
+    head :ok
+  end
+end

--- a/app/helpers/onboarding_helper.rb
+++ b/app/helpers/onboarding_helper.rb
@@ -1,0 +1,5 @@
+module OnboardingHelper
+  def show_onboarding_modal?
+    user_signed_in? && !current_user.onboarding_completed?
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import OnboardingController from "./onboarding_controller"
+application.register("onboarding", OnboardingController)

--- a/app/javascript/controllers/onboarding_controller.js
+++ b/app/javascript/controllers/onboarding_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "step", "nextBtn", "backBtn", "closeBtn", "stepLabel", "dot"]
+  static values = { completeUrl: String, currentStep: { type: Number, default: 0 } }
+
+  connect() {
+    if (this.element.dataset.showOnboarding === "true") {
+      this.showModal()
+    }
+    this.updateUI()
+  }
+
+  showModal() {
+    this.modalTarget.classList.remove("hidden")
+    document.body.classList.add("overflow-hidden")
+  }
+
+  hideModal() {
+    this.modalTarget.classList.add("hidden")
+    document.body.classList.remove("overflow-hidden")
+  }
+
+  next() {
+    if (this.currentStepValue < this.stepTargets.length - 1) {
+      this.currentStepValue++
+      this.updateUI()
+    }
+  }
+
+  back() {
+    if (this.currentStepValue > 0) {
+      this.currentStepValue--
+      this.updateUI()
+    }
+  }
+
+  close() {
+    this.hideModal()
+    this.markComplete()
+  }
+
+  skip() {
+    this.hideModal()
+    this.markComplete()
+  }
+
+  markComplete() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    fetch(this.completeUrlValue, {
+      method: "PATCH",
+      headers: {
+        "X-CSRF-Token": csrfToken,
+        "Content-Type": "application/json"
+      }
+    })
+  }
+
+  updateUI() {
+    const total = this.stepTargets.length
+    const current = this.currentStepValue
+
+    this.stepTargets.forEach((step, i) => {
+      step.classList.toggle("hidden", i !== current)
+    })
+
+    this.stepLabelTarget.textContent = `${current + 1} / ${total}`
+    this.dotTargets.forEach((dot, i) => {
+      dot.classList.toggle("bg-amber-700", i === current)
+      dot.classList.toggle("bg-gray-200", i !== current)
+    })
+
+    this.backBtnTarget.classList.toggle("invisible", current === 0)
+
+    const isLast = current === total - 1
+    this.nextBtnTarget.classList.toggle("hidden", isLast)
+    this.closeBtnTarget.classList.toggle("hidden", !isLast)
+  }
+}

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/onboarding_modal" %>
+
 <div class="max-w-3xl mx-auto py-10 px-4 space-y-8">
   <!-- ヘッダー（挨拶） -->
   <section>
@@ -8,6 +10,14 @@
     <p class="text-sm text-gray-600 mt-1">
       <%= t(".intro") %>
     </p>
+
+    <button
+      onclick="document.querySelector('[data-onboarding-target=modal]').classList.remove('hidden'); document.body.classList.add('overflow-hidden')"
+      class="mt-2 inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition underline underline-offset-2"
+      type="button"
+    >
+      <%= t(".actions.show_onboarding") %>
+    </button>
   </section>
 
   <% if @taste_profile.present? %>

--- a/app/views/shared/_onboarding_modal.html.erb
+++ b/app/views/shared/_onboarding_modal.html.erb
@@ -1,0 +1,91 @@
+<%
+  steps = t("shared.onboarding_modal.steps")
+  show_onboarding = show_onboarding_modal?
+%>
+
+<div
+  data-controller="onboarding"
+  data-onboarding-complete-url-value="<%= complete_onboarding_path %>"
+  data-show-onboarding="<%= show_onboarding %>"
+>
+  <!-- モーダル -->
+  <div
+    data-onboarding-target="modal"
+    class="<%= show_onboarding ? '' : 'hidden' %> fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+    role="dialog"
+    aria-modal="true"
+  >
+    <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm p-6 relative">
+      <!-- ヘッダー -->
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-base font-semibold text-stone-800">
+          <%= t("shared.onboarding_modal.title") %>
+        </h2>
+        <span data-onboarding-target="stepLabel" class="text-xs text-gray-400">
+          1 / <%= steps.size %>
+        </span>
+      </div>
+
+      <!-- ステップコンテンツ -->
+      <% steps.each_with_index do |step, i| %>
+        <div data-onboarding-target="step" class="<%= i == 0 ? '' : 'hidden' %> space-y-3 min-h-[120px]">
+          <p class="text-sm font-semibold text-amber-800"><%= step[:title] %></p>
+          <p class="text-sm text-stone-700 leading-relaxed"><%= step[:body] %></p>
+        </div>
+      <% end %>
+
+      <!-- ドットインジケーター -->
+      <div class="flex justify-center gap-1.5 mt-5">
+        <% steps.size.times do |i| %>
+          <span
+            data-onboarding-target="dot"
+            class="w-2 h-2 rounded-full <%= i == 0 ? 'bg-amber-700' : 'bg-gray-200' %>"
+          ></span>
+        <% end %>
+      </div>
+
+      <!-- ボタン -->
+      <div class="mt-5 flex items-center justify-between">
+        <button
+          data-onboarding-target="backBtn"
+          data-action="click->onboarding#back"
+          class="invisible px-4 py-2 text-sm text-gray-500 hover:text-gray-700 transition"
+          type="button"
+        >
+          <%= t("shared.onboarding_modal.actions.back") %>
+        </button>
+
+        <div class="flex gap-2">
+          <button
+            data-onboarding-target="nextBtn"
+            data-action="click->onboarding#next"
+            class="px-5 py-2 rounded-full text-sm font-semibold bg-amber-700 text-white hover:bg-amber-800 transition"
+            type="button"
+          >
+            <%= t("shared.onboarding_modal.actions.next") %>
+          </button>
+
+          <button
+            data-onboarding-target="closeBtn"
+            data-action="click->onboarding#close"
+            class="hidden px-5 py-2 rounded-full text-sm font-semibold bg-amber-700 text-white hover:bg-amber-800 transition"
+            type="button"
+          >
+            <%= t("shared.onboarding_modal.actions.close") %>
+          </button>
+        </div>
+      </div>
+
+      <!-- スキップ -->
+      <div class="mt-3 text-center">
+        <button
+          data-action="click->onboarding#skip"
+          class="text-xs text-gray-400 hover:text-gray-600 transition underline underline-offset-2"
+          type="button"
+        >
+          <%= t("shared.onboarding_modal.actions.skip") %>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,5 +1,22 @@
 ja:
   shared:
+    onboarding_modal:
+      title: "TrueCupの使い方"
+      step_label: "%{current} / %{total}"
+      steps:
+        - title: "STEP 1：味覚診断"
+          body: "いくつかの質問に答えるだけで、あなたのコーヒーの好みのタイプがわかります。まずは診断からスタートしましょう。"
+        - title: "STEP 2：コーヒーを記録"
+          body: "飲んだコーヒーの焙煎度・酸味・苦み・好み度などをサッと記録。難しい知識は不要です。"
+        - title: "STEP 3：傾向を可視化"
+          body: "記録が増えるほど、よく選ぶ焙煎度や好みの味わいの傾向がグラフで見えてきます。"
+        - title: "STEP 4：おすすめを確認"
+          body: "診断結果と記録データをもとに、あなたへのおすすめ焙煎度とお店での伝え方をご提案します。"
+      actions:
+        next: "次へ"
+        back: "戻る"
+        close: "はじめる"
+        skip: "スキップ"
     header:
       tagline: "コーヒーの「好き」が見つかるアプリ"
       menu: "メニュー"
@@ -134,6 +151,7 @@ ja:
         recent_logs: "最近の記録"
 
       actions:
+        show_onboarding: "使い方を見る"
         to_detail: "詳細へ"
         new_log: "新規記録"
         logs_index: "記録一覧"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get "/terms",   to: "static_pages#terms"
   get "/privacy", to: "static_pages#privacy"
   get "mypage", to: "mypage#show", as: :mypage
+  patch "onboarding/complete", to: "onboardings#complete", as: :complete_onboarding
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260329000000_add_onboarding_completed_to_users.rb
+++ b/db/migrate/20260329000000_add_onboarding_completed_to_users.rb
@@ -1,0 +1,5 @@
+class AddOnboardingCompletedToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :onboarding_completed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_13_075054) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_29_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_13_075054) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "onboarding_completed", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- users テーブルに onboarding_completed カラムを追加
- 4ステップのカルーセルモーダルで主要フロー（診断→記録→可視化→おすすめ）を説明
- 初回ログイン時のみ自動表示し、スキップ/完了で非表示（DB フラグ管理）
- mypage の挨拶欄に「使い方を見る」リンクで再表示可能