### PR TITLE
feat: コーヒーテーマのイラストを各画面に追加してビジュアルを強化する (#95)

### DIFF
--- a/app/views/coffee_logs/index.html.erb
+++ b/app/views/coffee_logs/index.html.erb
@@ -65,8 +65,9 @@
         </p>
       </div>
     <% else %>
-      <div class="bg-white rounded-xl shadow-sm p-6">
-        <p class="text-gray-700 font-medium"><%= t(".empty.no_logs") %></p>
+      <div class="bg-white rounded-xl shadow-sm p-8 text-center">
+        <%= render "shared/illustrations/coffee_empty" %>
+        <p class="text-gray-700 font-medium mt-4"><%= t(".empty.no_logs") %></p>
         <div class="mt-4">
           <%= link_to t(".actions.new"), new_coffee_log_path,
                       class: "inline-flex items-center px-4 py-2 rounded-full text-sm font-semibold bg-amber-700 text-white hover:bg-amber-800 transition" %>

--- a/app/views/coffee_logs/show.html.erb
+++ b/app/views/coffee_logs/show.html.erb
@@ -35,7 +35,10 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
       <div class="p-4 rounded border">
         <p class="text-gray-500"><%= t(".labels.roast_level") %></p>
-        <p class="font-semibold"><%= @coffee_log.roast_level_label %></p>
+        <p class="font-semibold flex items-center gap-2">
+          <%= render "shared/illustrations/coffee_bean", roast: @coffee_log.roast_level %>
+          <%= @coffee_log.roast_level_label %>
+        </p>
       </div>
       <div class="p-4 rounded border">
         <p class="text-gray-500"><%= t(".labels.rating") %></p>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -3,9 +3,12 @@
 <div class="max-w-3xl mx-auto py-10 px-4 space-y-8">
   <!-- ヘッダー（挨拶） -->
   <section>
-    <h1 class="text-xl sm:text-2xl font-semibold">
-      <%= t(".greeting", name: (@user.name.presence || @user.email)) %>
-    </h1>
+    <div class="flex items-center gap-3">
+      <%= render "shared/illustrations/coffee_icon" %>
+      <h1 class="text-xl sm:text-2xl font-semibold">
+        <%= t(".greeting", name: (@user.name.presence || @user.email)) %>
+      </h1>
+    </div>
 
     <p class="text-sm text-gray-600 mt-1">
       <%= t(".intro") %>

--- a/app/views/shared/_onboarding_modal.html.erb
+++ b/app/views/shared/_onboarding_modal.html.erb
@@ -29,6 +29,7 @@
       <!-- ステップコンテンツ -->
       <% steps.each_with_index do |step, i| %>
         <div data-onboarding-target="step" class="<%= i == 0 ? '' : 'hidden' %> space-y-3 min-h-[120px]">
+          <%= render "shared/illustrations/coffee_step", step: i + 1 %>
           <p class="text-sm font-semibold text-amber-800"><%= step[:title] %></p>
           <p class="text-sm text-stone-700 leading-relaxed"><%= step[:body] %></p>
         </div>

--- a/app/views/shared/illustrations/_coffee_bean.html.erb
+++ b/app/views/shared/illustrations/_coffee_bean.html.erb
@@ -1,0 +1,18 @@
+<%
+  # roast: "unknown" | "light" | "medium" | "medium_dark" | "dark"
+  roast ||= "unknown"
+  bean_color, crack_color = case roast.to_s
+  when "light"       then [ "#fbbf24", "#d97706" ]
+  when "medium"      then [ "#d97706", "#92400e" ]
+  when "medium_dark" then [ "#b45309", "#78350f" ]
+  when "dark"        then [ "#78350f", "#292524" ]
+  else                    [ "#d6d3d1", "#a8a29e" ]
+  end
+%>
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="shrink-0"
+     data-illustration="coffee-bean" data-roast="<%= roast %>">
+  <g transform="rotate(-35 16 16)">
+    <ellipse cx="16" cy="16" rx="13" ry="9" fill="<%= bean_color %>"/>
+    <path d="M5 16 Q10.5 20 16 16 T27 16" stroke="<%= crack_color %>" stroke-width="2" fill="none" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/app/views/shared/illustrations/_coffee_empty.html.erb
+++ b/app/views/shared/illustrations/_coffee_empty.html.erb
@@ -1,0 +1,21 @@
+<svg width="130" height="130" viewBox="0 0 130 130" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+     class="mx-auto max-w-full h-auto" data-illustration="coffee-empty">
+  <!-- Cup body (lighter, to suggest empty) -->
+  <path d="M22 42 Q65 38 108 42 L96 105 Q65 109 34 105 Z" fill="#fde68a"/>
+  <!-- Cup rim -->
+  <rect x="19" y="34" width="92" height="13" rx="6" fill="#fbbf24"/>
+  <!-- Inside of cup (empty - just a ring at bottom) -->
+  <ellipse cx="65" cy="97" rx="32" ry="5" fill="#d97706" opacity="0.15"/>
+
+  <!-- Handle -->
+  <path d="M98 55 Q118 55 118 72 Q118 89 98 89" stroke="#fbbf24" stroke-width="10" fill="none" stroke-linecap="round"/>
+
+  <!-- Saucer -->
+  <ellipse cx="65" cy="109" rx="55" ry="8" fill="#fcd34d"/>
+  <ellipse cx="65" cy="116" rx="62" ry="5" fill="#fde68a" opacity="0.6"/>
+
+  <!-- Dotted steam (faint, cup is empty) -->
+  <circle cx="50" cy="26" r="2" fill="#d97706" opacity="0.2"/>
+  <circle cx="65" cy="22" r="2" fill="#d97706" opacity="0.2"/>
+  <circle cx="80" cy="26" r="2" fill="#d97706" opacity="0.2"/>
+</svg>

--- a/app/views/shared/illustrations/_coffee_hero.html.erb
+++ b/app/views/shared/illustrations/_coffee_hero.html.erb
@@ -1,0 +1,38 @@
+<svg width="240" height="190" viewBox="0 0 240 190" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+     class="mx-auto max-w-full h-auto" data-illustration="coffee-hero">
+  <!-- Background coffee beans（割れ目は長軸に沿わせる） -->
+  <g transform="rotate(-30 28 90)">
+    <ellipse cx="28" cy="90" rx="13" ry="8" fill="#92400e" opacity="0.12"/>
+    <path d="M17 90 Q22.5 93 28 90 T39 90" stroke="#92400e" stroke-width="1.5" fill="none" opacity="0.16"/>
+  </g>
+  <g transform="rotate(25 212 70)">
+    <ellipse cx="212" cy="70" rx="13" ry="8" fill="#92400e" opacity="0.12"/>
+    <path d="M201 70 Q206.5 73 212 70 T223 70" stroke="#92400e" stroke-width="1.5" fill="none" opacity="0.16"/>
+  </g>
+  <g transform="rotate(-15 205 148)">
+    <ellipse cx="205" cy="148" rx="11" ry="7" fill="#92400e" opacity="0.1"/>
+    <path d="M196 148 Q200.5 150.5 205 148 T214 148" stroke="#92400e" stroke-width="1.5" fill="none" opacity="0.14"/>
+  </g>
+
+  <!-- Steam -->
+  <path d="M84 52 C82 42 87 33 84 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.45"/>
+  <path d="M120 46 C118 36 123 27 120 16" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.45"/>
+  <path d="M156 52 C154 42 159 33 156 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.45"/>
+
+  <!-- Cup body -->
+  <path d="M64 70 Q120 66 176 70 L162 148 Q120 153 78 148 Z" fill="#d97706"/>
+  <!-- Cup highlight -->
+  <path d="M82 88 Q105 84 128 88 L125 110 Q102 114 84 110 Z" fill="#fbbf24" opacity="0.25"/>
+  <!-- Cup rim -->
+  <rect x="58" y="62" width="124" height="14" rx="6" fill="#b45309"/>
+  <!-- Coffee surface -->
+  <ellipse cx="120" cy="68" rx="57" ry="7" fill="#78350f" opacity="0.55"/>
+
+  <!-- Handle -->
+  <path d="M170 88 Q200 88 200 110 Q200 132 170 132" stroke="#92400e" stroke-width="13" fill="none" stroke-linecap="round"/>
+  <path d="M170 88 Q194 88 194 110 Q194 132 170 132" stroke="#d97706" stroke-width="5" fill="none" stroke-linecap="round" opacity="0.35"/>
+
+  <!-- Saucer -->
+  <ellipse cx="120" cy="153" rx="80" ry="10" fill="#fbbf24"/>
+  <ellipse cx="120" cy="161" rx="90" ry="6" fill="#fcd34d" opacity="0.5"/>
+</svg>

--- a/app/views/shared/illustrations/_coffee_icon.html.erb
+++ b/app/views/shared/illustrations/_coffee_icon.html.erb
@@ -1,0 +1,19 @@
+<svg width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="shrink-0" data-illustration="coffee-icon">
+  <!-- Steam -->
+  <path d="M18 15 C17 11 19 8 18 4" stroke="#d97706" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.55"/>
+  <path d="M28 13 C27 9 29 6 28 2" stroke="#d97706" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.55"/>
+  <path d="M38 15 C37 11 39 8 38 4" stroke="#d97706" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.55"/>
+
+  <!-- Cup body -->
+  <path d="M11 22 Q28 19 45 22 L40 46 Q28 48 16 46 Z" fill="#d97706"/>
+  <!-- Cup rim -->
+  <rect x="9" y="17" width="38" height="9" rx="4" fill="#b45309"/>
+  <!-- Coffee surface -->
+  <ellipse cx="28" cy="21" rx="17" ry="4" fill="#78350f" opacity="0.5"/>
+
+  <!-- Handle -->
+  <path d="M40 28 Q50 28 50 36 Q50 44 40 44" stroke="#92400e" stroke-width="5" fill="none" stroke-linecap="round"/>
+
+  <!-- Saucer -->
+  <ellipse cx="28" cy="48" rx="23" ry="4" fill="#fbbf24"/>
+</svg>

--- a/app/views/shared/illustrations/_coffee_roast.html.erb
+++ b/app/views/shared/illustrations/_coffee_roast.html.erb
@@ -1,0 +1,31 @@
+<%
+  # roast: "light" | "medium" | "medium_dark" | "dark"
+  roast ||= "medium"
+  cup_color, rim_color, surface_color, handle_color = case roast.to_s
+    when "light"       then ["#fbbf24", "#f59e0b", "#d97706", "#d97706"]
+    when "medium"      then ["#d97706", "#b45309", "#92400e", "#b45309"]
+    when "medium_dark" then ["#b45309", "#92400e", "#78350f", "#92400e"]
+    when "dark"        then ["#78350f", "#451a03", "#1c1917", "#451a03"]
+    else                    ["#d97706", "#b45309", "#92400e", "#b45309"]
+  end
+%>
+<svg width="120" height="110" viewBox="0 0 120 110" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+     class="mx-auto max-w-full h-auto" data-illustration="coffee-roast" data-roast="<%= roast %>">
+  <!-- Steam（焙煎度によらず湯気の色は固定。深煎りで煙のように見えるのを防ぐ） -->
+  <path d="M38 30 C37 22 40 16 38 8" stroke="#d97706" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+  <path d="M60 26 C59 18 62 12 60 4" stroke="#d97706" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+  <path d="M82 30 C81 22 84 16 82 8" stroke="#d97706" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.5"/>
+
+  <!-- Cup body -->
+  <path d="M18 42 Q60 38 102 42 L92 90 Q60 94 28 90 Z" fill="<%= cup_color %>"/>
+  <!-- Cup rim -->
+  <rect x="15" y="35" width="90" height="11" rx="5" fill="<%= rim_color %>"/>
+  <!-- Coffee surface -->
+  <ellipse cx="60" cy="40" rx="42" ry="5.5" fill="<%= surface_color %>" opacity="0.7"/>
+
+  <!-- Handle -->
+  <path d="M93 53 Q112 53 112 66 Q112 79 93 79" stroke="<%= handle_color %>" stroke-width="9" fill="none" stroke-linecap="round"/>
+
+  <!-- Saucer -->
+  <ellipse cx="60" cy="93" rx="58" ry="8" fill="#fbbf24"/>
+</svg>

--- a/app/views/shared/illustrations/_coffee_step.html.erb
+++ b/app/views/shared/illustrations/_coffee_step.html.erb
@@ -1,0 +1,48 @@
+<%
+  # step: 1..4（オンボーディングのステップ番号に対応）
+  step ||= 1
+%>
+<svg width="104" height="76" viewBox="0 0 104 76" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
+     class="mx-auto max-w-full h-auto" data-illustration="coffee-step" data-step="<%= step %>">
+  <% case step.to_i %>
+  <% when 1 %>
+    <%# STEP 1：味覚診断 — カップと「？」 %>
+    <path d="M22 30 Q42 27 62 30 L57 60 Q42 63 27 60 Z" fill="#d97706"/>
+    <rect x="20" y="25" width="44" height="10" rx="5" fill="#b45309"/>
+    <ellipse cx="42" cy="29" rx="20" ry="4" fill="#78350f" opacity="0.5"/>
+    <path d="M57 38 Q69 38 69 46 Q69 54 57 54" stroke="#92400e" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <ellipse cx="42" cy="63" rx="27" ry="5" fill="#fbbf24"/>
+    <path d="M76 26 Q76 16 84 16 Q92 16 92 24 Q92 30 84 32 L84 38"
+          stroke="#f59e0b" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="84" cy="48" r="3.5" fill="#f59e0b"/>
+  <% when 2 %>
+    <%# STEP 2：コーヒーを記録 — ノートとペン %>
+    <rect x="16" y="14" width="46" height="52" rx="5" fill="#fef3c7"/>
+    <rect x="16" y="14" width="9" height="52" rx="4" fill="#fbbf24"/>
+    <line x1="32" y1="28" x2="55" y2="28" stroke="#d97706" stroke-width="3" stroke-linecap="round" opacity="0.7"/>
+    <line x1="32" y1="38" x2="55" y2="38" stroke="#d97706" stroke-width="3" stroke-linecap="round" opacity="0.5"/>
+    <line x1="32" y1="48" x2="46" y2="48" stroke="#d97706" stroke-width="3" stroke-linecap="round" opacity="0.35"/>
+    <path d="M72 56 L72 44 L88 24 L96 30 L80 50 Z" fill="#b45309"/>
+    <path d="M72 56 L72 48 L77 52 Z" fill="#78350f"/>
+    <path d="M88 24 L96 30" stroke="#fbbf24" stroke-width="3" stroke-linecap="round"/>
+  <% when 3 %>
+    <%# STEP 3：傾向を可視化 — 棒グラフ %>
+    <line x1="20" y1="62" x2="88" y2="62" stroke="#d97706" stroke-width="3" stroke-linecap="round" opacity="0.4"/>
+    <rect x="26" y="42" width="13" height="20" rx="3" fill="#fbbf24"/>
+    <rect x="45" y="26" width="13" height="36" rx="3" fill="#d97706"/>
+    <rect x="64" y="34" width="13" height="28" rx="3" fill="#b45309"/>
+    <path d="M28 20 Q46 8 70 14" stroke="#92400e" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.35"/>
+    <circle cx="70" cy="14" r="3.5" fill="#92400e" opacity="0.35"/>
+  <% else %>
+    <%# STEP 4：おすすめを確認 — カップときらめき %>
+    <path d="M14 24 C13 18 16 14 14 8" stroke="#d97706" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+    <path d="M30 20 C29 14 32 10 30 4" stroke="#d97706" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+    <path d="M8 30 Q36 27 64 30 L57 60 Q36 63 15 60 Z" fill="#d97706"/>
+    <rect x="6" y="25" width="60" height="10" rx="5" fill="#b45309"/>
+    <ellipse cx="36" cy="29" rx="28" ry="4" fill="#78350f" opacity="0.5"/>
+    <path d="M60 38 Q74 38 74 46 Q74 54 60 54" stroke="#92400e" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <ellipse cx="36" cy="63" rx="34" ry="5" fill="#fbbf24"/>
+    <path d="M86 12 L89 21 L98 24 L89 27 L86 36 L83 27 L74 24 L83 21 Z" fill="#f59e0b"/>
+    <path d="M92 46 L93.5 50.5 L98 52 L93.5 53.5 L92 58 L90.5 53.5 L86 52 L90.5 50.5 Z" fill="#fbbf24"/>
+  <% end %>
+</svg>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -2,6 +2,7 @@
   <!-- ヒーローセクション -->
   <section class="py-10 md:py-14">
     <div class="max-w-3xl mx-auto space-y-6 text-center">
+      <%= render "shared/illustrations/coffee_hero" %>
       <p class="inline-block text-xs md:text-sm tracking-wide uppercase text-amber-700 font-semibold">
         <%= t(".hero.kicker") %>
       </p>

--- a/app/views/taste_profiles/show.html.erb
+++ b/app/views/taste_profiles/show.html.erb
@@ -17,6 +17,7 @@
   </h1>
 
   <div class="bg-white rounded-xl shadow-sm p-6 space-y-4">
+    <%= render "shared/illustrations/coffee_roast", roast: roast_key %>
     <div class="flex items-center justify-between gap-3">
       <p class="text-sm text-gray-600">
         <%= t(".diagnosed_on", date: l(@taste_profile.diagnosed_at.to_date, format: :long)) %>

--- a/app/views/trial_results/show.html.erb
+++ b/app/views/trial_results/show.html.erb
@@ -14,6 +14,7 @@
   </h1>
 
   <div class="bg-white rounded-xl shadow-sm p-6 space-y-4">
+    <%= render "shared/illustrations/coffee_roast", roast: roast_key %>
     <div class="flex items-center justify-between gap-3">
       <% if @from_trial %>
         <p class="text-sm text-gray-600">

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,71 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="utf-8">
+  <title>ページが見つかりません - True Cup</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #fffbeb;
+      color: #292524;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      text-align: center;
+    }
+    .container { max-width: 480px; width: 100%; }
+    svg { margin: 0 auto 2rem; display: block; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: #92400e; }
+    p { font-size: 0.95rem; color: #57534e; line-height: 1.7; margin-bottom: 1.5rem; }
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.65rem 1.5rem;
+      border-radius: 9999px;
+      background-color: #b45309;
+      color: #fff;
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background-color 0.15s;
+    }
+    a:hover { background-color: #92400e; }
+    .code { font-size: 4rem; font-weight: 800; color: #fde68a; margin-bottom: 1rem; letter-spacing: -2px; }
   </style>
 </head>
+<body>
+  <div class="container">
+    <svg width="200" height="170" viewBox="0 0 200 170" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <!-- Coffee puddle -->
+      <ellipse cx="102" cy="148" rx="72" ry="16" fill="#92400e" opacity="0.22"/>
+      <ellipse cx="95" cy="148" rx="50" ry="10" fill="#92400e" opacity="0.28"/>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
+      <!-- Fallen cup -->
+      <g transform="translate(100,85) rotate(80) translate(-38,-28)">
+        <path d="M6 18 L70 18 L62 56 L14 56 Z" fill="#d97706"/>
+        <rect x="3" y="12" width="68" height="11" rx="5" fill="#b45309"/>
+        <ellipse cx="38" cy="17" rx="31" ry="5" fill="#78350f" opacity="0.55"/>
+        <path d="M62 26 Q80 26 80 38 Q80 50 62 50" stroke="#92400e" stroke-width="8" fill="none" stroke-linecap="round"/>
+      </g>
+
+      <!-- Coffee drips -->
+      <circle cx="68" cy="128" r="5" fill="#92400e" opacity="0.4"/>
+      <circle cx="136" cy="122" r="3.5" fill="#92400e" opacity="0.35"/>
+      <circle cx="104" cy="132" r="4" fill="#92400e" opacity="0.38"/>
+      <path d="M82 108 Q78 120 72 130" stroke="#92400e" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.35"/>
+      <path d="M122 105 Q126 118 132 126" stroke="#92400e" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.3"/>
+    </svg>
+
+    <div class="code" aria-hidden="true">404</div>
+    <h1>ページが見つかりません</h1>
+    <p>お探しのページは移動または削除された可能性があります。<br>コーヒーでも飲みながら、トップページへどうぞ。</p>
+    <a href="/">トップページへ戻る</a>
   </div>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,71 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="utf-8">
+  <title>この操作は実行できません - True Cup</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #fffbeb;
+      color: #292524;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      text-align: center;
+    }
+    .container { max-width: 480px; width: 100%; }
+    svg { margin: 0 auto 2rem; display: block; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: #92400e; }
+    p { font-size: 0.95rem; color: #57534e; line-height: 1.7; margin-bottom: 1.5rem; }
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.65rem 1.5rem;
+      border-radius: 9999px;
+      background-color: #b45309;
+      color: #fff;
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background-color 0.15s;
+    }
+    a:hover { background-color: #92400e; }
+    .code { font-size: 4rem; font-weight: 800; color: #fde68a; margin-bottom: 1rem; letter-spacing: -2px; }
   </style>
 </head>
+<body>
+  <div class="container">
+    <svg width="200" height="170" viewBox="0 0 200 170" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <!-- Steam -->
+      <path d="M76 44 C74 36 79 30 76 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.35"/>
+      <path d="M100 40 C98 32 103 26 100 18" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.35"/>
+      <path d="M124 44 C122 36 127 30 124 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.35"/>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
+      <!-- Cup -->
+      <path d="M52 62 Q100 58 148 62 L136 132 Q100 137 64 132 Z" fill="#d97706"/>
+      <rect x="46" y="54" width="108" height="13" rx="6" fill="#b45309"/>
+      <ellipse cx="100" cy="60" rx="48" ry="5" fill="#78350f" opacity="0.45"/>
+      <path d="M144 76 Q164 76 164 92 Q164 108 144 108" stroke="#92400e" stroke-width="9" fill="none" stroke-linecap="round"/>
+
+      <!-- Saucer -->
+      <ellipse cx="100" cy="137" rx="62" ry="9" fill="#fbbf24"/>
+
+      <!-- "Not allowed" sign over the cup -->
+      <circle cx="146" cy="42" r="24" fill="#fef3c7"/>
+      <circle cx="146" cy="42" r="24" fill="none" stroke="#b45309" stroke-width="5"/>
+      <line x1="131" y1="57" x2="161" y2="27" stroke="#b45309" stroke-width="5" stroke-linecap="round"/>
+    </svg>
+
+    <div class="code" aria-hidden="true">422</div>
+    <h1>この操作は実行できません</h1>
+    <p>リクエストの内容が正しくないため、処理を中断しました。<br>お手数ですが、最初からやり直してください。</p>
+    <a href="/">トップページへ戻る</a>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,75 @@
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="utf-8">
+  <title>問題が発生しました - True Cup</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
-
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #fffbeb;
+      color: #292524;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      text-align: center;
+    }
+    .container { max-width: 480px; width: 100%; }
+    svg { margin: 0 auto 2rem; display: block; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.5rem; color: #92400e; }
+    p { font-size: 0.95rem; color: #57534e; line-height: 1.7; margin-bottom: 1.5rem; }
+    a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.65rem 1.5rem;
+      border-radius: 9999px;
+      background-color: #b45309;
+      color: #fff;
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background-color 0.15s;
+    }
+    a:hover { background-color: #92400e; }
+    .code { font-size: 4rem; font-weight: 800; color: #fde68a; margin-bottom: 1rem; letter-spacing: -2px; }
   </style>
 </head>
+<body>
+  <div class="container">
+    <svg width="200" height="170" viewBox="0 0 200 170" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <!-- Broken steam -->
+      <path d="M78 44 C76 36 81 30 78 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.25"/>
+      <path d="M122 44 C120 36 125 30 122 22" stroke="#d97706" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.25"/>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
+      <!-- Cup -->
+      <path d="M52 62 Q100 58 148 62 L136 132 Q100 137 64 132 Z" fill="#d97706"/>
+      <rect x="46" y="54" width="108" height="13" rx="6" fill="#b45309"/>
+      <ellipse cx="100" cy="60" rx="48" ry="5" fill="#78350f" opacity="0.45"/>
+      <path d="M144 76 Q164 76 164 92 Q164 108 144 108" stroke="#92400e" stroke-width="9" fill="none" stroke-linecap="round"/>
+
+      <!-- Crack running down the cup -->
+      <path d="M100 56 L92 76 L106 92 L94 110 L102 134"
+            stroke="#fffbeb" stroke-width="6" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+      <path d="M92 76 L78 82" stroke="#fffbeb" stroke-width="5" fill="none" stroke-linecap="round"/>
+      <path d="M106 92 L122 96" stroke="#fffbeb" stroke-width="5" fill="none" stroke-linecap="round"/>
+
+      <!-- Saucer -->
+      <ellipse cx="100" cy="137" rx="62" ry="9" fill="#fbbf24"/>
+
+      <!-- Leaked drops -->
+      <circle cx="76" cy="150" r="4.5" fill="#92400e" opacity="0.3"/>
+      <circle cx="118" cy="153" r="3.5" fill="#92400e" opacity="0.25"/>
+    </svg>
+
+    <div class="code" aria-hidden="true">500</div>
+    <h1>問題が発生しました</h1>
+    <p>一時的なエラーが発生しました。<br>お手数ですが、しばらく経ってからもう一度お試しください。</p>
+    <a href="/">トップページへ戻る</a>
   </div>
 </body>
 </html>

--- a/spec/requests/coffee_logs_spec.rb
+++ b/spec/requests/coffee_logs_spec.rb
@@ -19,8 +19,15 @@ RSpec.describe "CoffeeLogs", type: :request do
       it "記録が表示されること" do
         get coffee_logs_path
         user.coffee_logs.each do |log|
-          expect(response.body).to include(log.coffee_name)
+          expect(response.body).to include(ERB::Util.html_escape(log.coffee_name))
         end
+      end
+    end
+
+    context "記録が1件もない場合" do
+      it "空状態のイラストが表示されること" do
+        get coffee_logs_path
+        expect(response.body).to include('data-illustration="coffee-empty"')
       end
     end
 
@@ -42,7 +49,22 @@ RSpec.describe "CoffeeLogs", type: :request do
     it "記録詳細ページが表示されること" do
       get coffee_log_path(coffee_log)
       expect(response).to have_http_status(:success)
-      expect(response.body).to include(coffee_log.coffee_name)
+      expect(response.body).to include(ERB::Util.html_escape(coffee_log.coffee_name))
+    end
+
+    it "焙煎度に対応したコーヒー豆アイコンが表示されること" do
+      get coffee_log_path(coffee_log)
+      expect(response.body).to include('data-illustration="coffee-bean"')
+      expect(response.body).to include('data-roast="medium"')
+    end
+
+    context "焙煎度が深煎りの記録の場合" do
+      let(:coffee_log) { create(:coffee_log, :dark_roast, user: user) }
+
+      it "深煎り用のアイコンが表示されること" do
+        get coffee_log_path(coffee_log)
+        expect(response.body).to include('data-roast="dark"')
+      end
     end
   end
 

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe "Mypage", type: :request do
         expect(response.body).to include("マイページ")
       end
 
+      it "挨拶の横にコーヒーアイコンが表示されること" do
+        get mypage_path
+        expect(response.body).to include('data-illustration="coffee-icon"')
+      end
+
+      it "オンボーディングの各ステップに異なるイラストが表示されること" do
+        get mypage_path
+
+        # data-step 属性は必ず異なるため、SVGの中身（描画内容）だけを比較する
+        drawings = response.body.scan(%r{<svg[^>]*data-illustration="coffee-step"[^>]*>(.*?)</svg>}m).flatten
+        expect(drawings.size).to eq(I18n.t("shared.onboarding_modal.steps").size)
+        expect(drawings.uniq.size).to eq(drawings.size)
+      end
+
       context "味覚診断が未実施の場合" do
         it "診断を促すメッセージが表示されること" do
           get mypage_path
@@ -41,7 +55,7 @@ RSpec.describe "Mypage", type: :request do
 
         it "最新の記録が表示されること" do
           get mypage_path
-          expect(response.body).to include(user.coffee_logs.first.coffee_name)
+          expect(response.body).to include(ERB::Util.html_escape(user.coffee_logs.first.coffee_name))
         end
       end
     end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /" do
+    it "TOPページが表示されること" do
+      get root_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "ヒーローイラストが表示されること" do
+      get root_path
+      expect(response.body).to include('data-illustration="coffee-hero"')
+    end
+
+    context "ログイン済みの場合" do
+      before { sign_in create(:user) }
+
+      it "マイページにリダイレクトされること" do
+        get root_path
+        expect(response).to redirect_to(mypage_path)
+      end
+    end
+  end
+
+  describe "GET /terms" do
+    it "利用規約が表示されること" do
+      get terms_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /privacy" do
+    it "プライバシーポリシーが表示されること" do
+      get privacy_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/taste_profiles_spec.rb
+++ b/spec/requests/taste_profiles_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "TasteProfiles", type: :request do
+  describe "GET /taste_profile" do
+    context "ログインしていない場合" do
+      it "ログインページにリダイレクトされること" do
+        get taste_profile_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "診断済みの場合" do
+      let(:user) { create(:user, :with_taste_profile) }
+
+      before { sign_in user }
+
+      it "診断結果ページが表示されること" do
+        get taste_profile_path
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(I18n.t("taste_profiles.show.heading"))
+      end
+
+      it "診断結果の焙煎度に対応したイラストが表示されること" do
+        get taste_profile_path
+        expect(response.body).to include('data-illustration="coffee-roast"')
+        expect(response.body).to include('data-roast="medium"')
+      end
+    end
+
+    context "浅煎りタイプと診断された場合" do
+      let(:user) { create(:user) }
+
+      before do
+        create(:taste_profile, :light_like, user: user)
+        sign_in user
+      end
+
+      it "浅煎り用のイラストが表示されること" do
+        get taste_profile_path
+        expect(response.body).to include('data-roast="light"')
+      end
+    end
+  end
+end

--- a/spec/requests/trial_results_spec.rb
+++ b/spec/requests/trial_results_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "TrialResults", type: :request do
+  describe "GET /trial_results/:type" do
+    it "未ログインでも試し診断の結果ページが表示されること" do
+      get trial_result_path(type: "medium")
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(I18n.t("taste_profiles.show.heading"))
+    end
+
+    it "焙煎度に対応したイラストが表示されること" do
+      get trial_result_path(type: "dark")
+      expect(response.body).to include('data-illustration="coffee-roast"')
+      expect(response.body).to include('data-roast="dark"')
+    end
+
+    it "焙煎度ごとにイラストの配色が変わること" do
+      # data-roast 属性は必ず異なるため、SVGの中身（配色）だけを比較する
+      drawings = %w[light medium medium_dark dark].map do |roast|
+        get trial_result_path(type: roast)
+        response.body[%r{<svg[^>]*data-illustration="coffee-roast"[^>]*>(.*?)</svg>}m, 1]
+      end
+
+      expect(drawings).to all(be_present)
+      expect(drawings.uniq.size).to eq(drawings.size)
+    end
+
+    context "不正な焙煎度が指定された場合" do
+      it "ルーティングにマッチせず404になること" do
+        get "/trial_results/invalid_roast"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/views/error_pages_spec.rb
+++ b/spec/views/error_pages_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+# public/ 配下の静的エラーページはRailsを経由しないため、ファイルの内容を直接検証する
+RSpec.describe "静的エラーページ" do
+  {
+    "404" => "ページが見つかりません",
+    "422" => "この操作は実行できません",
+    "500" => "問題が発生しました"
+  }.each do |code, heading|
+    describe "public/#{code}.html" do
+      let(:html) { Rails.root.join("public", "#{code}.html").read }
+
+      it "Railsのデフォルトではなく、アプリのデザインになっていること" do
+        expect(html).not_to include("rails-default-error-page")
+        expect(html).to include('<html lang="ja">')
+        expect(html).to include(heading)
+      end
+
+      it "コーヒーのイラストが装飾として埋め込まれていること" do
+        expect(html).to include("<svg")
+        expect(html).to include('aria-hidden="true"')
+      end
+
+      it "トップページへの導線があること" do
+        expect(html).to include('href="/"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #95

## 概要

想定ユーザーであるコーヒー初心者・ライトユーザー向けに、文字中心だった画面をイラストで視覚的に補強する。
CLAUDE.md の「説明はイラスト・グラフなど視覚的な手段を優先する」という方針に沿った対応。

## 実装方針

イラストは `app/views/shared/illustrations/` にインラインSVGの部分テンプレートとして切り出した。

- **外部画像リクエストを増やさない** — 画像ファイルではなくインラインSVGにしたため、追加のHTTPリクエストが発生しない
- **配色は既存の amber / stone パレットに統一**
- **装飾要素なので `aria-hidden="true"`** を付与し、スクリーンリーダーからは読み上げられないようにしている

## 追加したイラストと配置先

| 部分テンプレート | 配置先 |
| --- | --- |
| `coffee_hero` | TOP のヒーローセクション |
| `coffee_roast` | 診断結果 / 試し診断結果（**焙煎度に応じて配色が変化**） |
| `coffee_bean` | 記録詳細の焙煎度表示 |
| `coffee_empty` | 記録一覧の空状態 |
| `coffee_icon` | マイページの挨拶 |
| `coffee_step` | オンボーディングモーダルの各ステップ |

`coffee_roast` は light / medium / medium_dark / dark で豆の色が変わる。
湯気の色だけは焙煎度によらず固定にしている（深煎りで配色を暗くすると煙のように見えてしまうため）。

## エラーページの刷新

`public/404.html` `422.html` `500.html` が Rails デフォルトの英語ページのままだったため、
アプリのデザインに合わせて作り直した。

- 日本語の案内文
- コーヒーのイラスト
- トップページへの導線

これらは Rails を経由しない静的ファイルのため、`spec/views/error_pages_spec.rb` でファイル内容を直接検証している。

## テスト

テストからイラストを識別できるよう `data-illustration` / `data-roast` 属性を付与した。

新規に `spec/requests/static_pages_spec.rb` `taste_profiles_spec.rb` `trial_results_spec.rb`、
`spec/views/error_pages_spec.rb` を追加（既存 spec が無かった画面のため、イラスト以外の基本的な表示・認証も併せてカバー）。

焙煎度ごとの描き分けは `data-roast` 属性だけを見ても意味がないため、**SVGの中身を抽出して全4種が互いに異なること**を検証している。

```ruby
drawings = %w[light medium medium_dark dark].map do |roast|
  get trial_result_path(type: roast)
  response.body[%r{<svg[^>]*data-illustration="coffee-roast"[^>]*>(.*?)</svg>}m, 1]
end
expect(drawings.uniq.size).to eq(drawings.size)
```

### 既存 spec の修正

Faker 由来の `coffee_name` を HTML 本文と突き合わせている箇所で、`'` を含む値がエスケープされて
不一致になる潜在的な不安定さがあったため `ERB::Util.html_escape` を通すよう修正した。

## 確認したこと

ローカル（Docker）で CI の3ジョブ相当をすべて実行済み。

| チェック | 結果 |
| --- | --- |
| `bundle exec rspec` | 135 examples, 0 failures |
| `bin/rubocop` | 84 files inspected, no offenses |
| `bin/brakeman --no-pager` | Security Warnings: 0 |

> **補足**: 現状 CI は RSpec を実行していない（`test/` の Minitest のみ）ため、上記 RSpec の結果は PR 上には現れません。
> この点は別途 Issue を立てて対応予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)