### PR TITLE
fix: 未ログインでのアカウント削除確認ページが500になる問題を修正 (#103)

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,10 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-  before_action :authenticate_user!, only: [ :confirm_deletion ]
+  # devise コントローラー内では authenticate_user! が force オプションなしでは素通りするため、
+  # Devise 標準の authenticate_scope!（内部で force: true を渡す）で保護する。
+  # 同名コールバックの再宣言は既存の条件を置き換えるため、Devise 既定の対象アクションもここに含めること。
+  prepend_before_action :authenticate_scope!, only: [ :edit, :update, :destroy, :confirm_deletion ]
 
   def confirm_deletion
     @user = current_user

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -90,6 +90,40 @@ RSpec.describe "Users", type: :request do
     end
   end
 
+  # confirm_deletion の保護のために authenticate_scope! を再宣言しており、
+  # 同名コールバックの再宣言は Devise 既定の条件を置き換える。
+  # edit / update の保護が落ちていないことをここで担保する。
+  describe "アカウント編集" do
+    let(:user) { create(:user) }
+
+    describe "GET /users/edit" do
+      context "ログインしていない場合" do
+        it "ログインページにリダイレクトされること" do
+          get edit_user_registration_path
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+
+      context "ログインしている場合" do
+        before { sign_in user }
+
+        it "編集ページが表示されること" do
+          get edit_user_registration_path
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
+
+    describe "PATCH /users" do
+      context "ログインしていない場合" do
+        it "ログインページにリダイレクトされること" do
+          patch user_registration_path, params: { user: { name: "改名" } }
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+    end
+  end
+
   describe "アカウント削除" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
Closes #103

## 概要

`Users::RegistrationsController#confirm_deletion` の認可ガードが機能しておらず、
未ログインでアクセスすると 500 エラーになっていた問題を修正する。

## 原因

```ruby
before_action :authenticate_user!, only: [ :confirm_deletion ]
```

Devise の `authenticate_user!` は次の実装になっている。

```ruby
def authenticate_#{mapping}!(opts = {})
  opts[:scope] = :#{mapping}
  warden.authenticate!(opts) if !devise_controller? || opts.delete(:force)
end
```

**`devise_controller?` が true のコントローラーでは `force: true` がない限り素通りする。**
`Users::RegistrationsController` は Devise コントローラーなので、この `before_action` は **no-op** だった。

再現（修正前）:

```
ActionView::Template::Error:
  undefined method `coffee_logs' for nil
  ./app/views/users/registrations/confirm_deletion.html.erb:32
```

`@user = current_user` が nil のままビューが描画されるため落ちる。

### 影響範囲

`edit` / `update` / `destroy` は Devise 本体が `prepend_before_action :authenticate_scope!` で保護しているため無傷。
**アカウント削除が未認証で実行できる状態ではなく、情報漏洩もない**（描画前に落ちるため）。実害は 500 エラー。

## 修正

```ruby
prepend_before_action :authenticate_scope!, only: [ :edit, :update, :destroy, :confirm_deletion ]
```

`authenticate_scope!` は Devise 標準のメソッドで、内部で `force: true` を渡すため Devise コントローラー内でも機能する。

> **注意点**: 同名コールバックの再宣言は既存の条件を**置き換える**ため、
> Devise 既定の対象である `edit` / `update` / `destroy` もリストに含める必要がある。
> ここを落とすとアカウント編集が無防備になる。コード中にもコメントとして残した。

## テスト

この落とし穴を踏んでも気づけるよう、`edit` / `update` の認可を確認する spec を追加した。

```ruby
# confirm_deletion の保護のために authenticate_scope! を再宣言しており、
# 同名コールバックの再宣言は Devise 既定の条件を置き換える。
# edit / update の保護が落ちていないことをここで担保する。
describe "アカウント編集" do
```

## この不具合が見逃されていた理由

**既存の spec はこの不具合を最初から検知していた。**

修正前の状態で `spec/requests/users_spec.rb` を実行した結果:

```
1) Users アカウント削除 GET /users/confirm_deletion ログインしていない場合 ログインページにリダイレクトされること
   ActionView::Template::Error:
     undefined method `coffee_logs' for nil

15 examples, 1 failure
```

このテストは #90（ユーザー削除機能）で追加されて以来ずっと失敗していたが、
**CI が RSpec を実行していない**（`test/` の Minitest のみ）ため誰も気づけなかった。

CI 設定の是正は次の PR で対応する。本 PR のテストも、それまでは CI 上に結果が現れない点に注意。

## 確認したこと

| チェック | 結果 |
| --- | --- |
| `bundle exec rspec` | 138 examples, 0 failures |
| `bin/rubocop` | 84 files inspected, no offenses |

修正前後で `spec/requests/users_spec.rb` が 1 failure → 0 failures になることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)