### PR TITLE
refactor: enum を位置引数の記法に変更する (#100 の準備)

### DIFF
--- a/app/models/coffee_log.rb
+++ b/app/models/coffee_log.rb
@@ -1,9 +1,9 @@
 class CoffeeLog < ApplicationRecord
   belongs_to :user
 
-  enum place: { cafe: 0, home: 1, other: 99 }, _prefix: true
-  enum roast_level: { unknown: 0, light: 1, medium: 2, medium_dark: 3, dark: 4 }, _prefix: true
-  enum brew_method: { unknown: 0, pour_over: 1, nel: 2, espresso: 3, french_press: 4, other: 99 }, _prefix: true
+  enum :place, { cafe: 0, home: 1, other: 99 }, prefix: true
+  enum :roast_level, { unknown: 0, light: 1, medium: 2, medium_dark: 3, dark: 4 }, prefix: true
+  enum :brew_method, { unknown: 0, pour_over: 1, nel: 2, espresso: 3, french_press: 4, other: 99 }, prefix: true
 
   validates :drank_on, :place, :roast_level, :bitterness, :acidity, :overall_rating, presence: true
   validates :coffee_name, length: { maximum: 100 }, allow_blank: true

--- a/app/models/taste_profile.rb
+++ b/app/models/taste_profile.rb
@@ -1,7 +1,7 @@
 class TasteProfile < ApplicationRecord
   belongs_to :user
 
-  enum preferred_roast: {
+  enum :preferred_roast, {
     light: 0,        # 浅煎りタイプ
     medium: 1,       # 中煎りタイプ
     medium_dark: 2,  # 中深煎りタイプ
@@ -9,7 +9,7 @@ class TasteProfile < ApplicationRecord
   }
 
   # 味覚タイプ（MVPでは preferred_roast とほぼ同義でOK）
-  enum taste_type: {
+  enum :taste_type, {
     light_like: 0,
     medium_like: 1,
     medium_dark_like: 2,


### PR DESCRIPTION
#100 のチェックリスト「enum のキーワード引数記法の書き換え」に対応します。
**#100 自体は Rails 8 本体の対応が残るため open のままにします。**

## 概要

キーワード引数による enum 定義は Rails 8 で削除されるため、位置引数の記法へ書き換える。

```diff
-  enum place: { cafe: 0, home: 1, other: 99 }, _prefix: true
+  enum :place, { cafe: 0, home: 1, other: 99 }, prefix: true
```

対象は5箇所。

| モデル | enum |
| --- | --- |
| `CoffeeLog` | `place` / `roast_level` / `brew_method` |
| `TasteProfile` | `preferred_roast` / `taste_type` |

## なぜ Rails 8 本体と分けるのか

**この変更は Rails 7.2 のままでも動作します。** 先に取り込んでおくことで、Rails 8 本体の PR の差分を
アップグレード起因のものだけに絞れて、問題が起きたときの切り分けが楽になります。

## 解消される警告

テスト実行のたびに以下が5件出ていた状態が解消されます。

```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:

enum :place, {:cafe=>0, :home=>1, :other=>99}
 (called from <class:CoffeeLog> at /myapp/app/models/coffee_log.rb:4)
```

## 生成メソッドに変化がないことの確認

`_prefix: true` → `prefix: true` で挙動が変わらないことを実際に確認しました。

```
place methods:  [:place_cafe!, :place_cafe?, :place_home!, :place_home?, :place_other!, :place_other?]
roast scopes:   [:roast_level_dark, :roast_level_light, :roast_level_medium, :roast_level_medium_dark, :roast_level_unknown]
TasteProfile:   [:dark!, :dark?, :dark_like!, :dark_like?, :light!, :light?, ...]
```

`place_cafe?` は以下の3箇所で使用しています。

- `app/views/coffee_logs/show.html.erb:25`
- `app/views/coffee_logs/index.html.erb:25`
- `app/views/mypage/show.html.erb:213`

## 確認したこと

| チェック | 結果 |
| --- | --- |
| `bundle exec rspec` | 139 examples, 0 failures |
| `bin/rubocop` | 74 files inspected, no offenses |
| `bin/brakeman --no-pager` | Security Warnings: 0 |
| enum の deprecation warning | **0件（解消）** |

## 補足

テスト実行時には別の deprecation warning が残っています。

```
Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack.
Please use :unprocessable_content instead.
```

これは Rack 由来で Rails 8 とは独立した話です。自前の spec 側は `:unprocessable_content` へ置き換え可能ですが、
`devise` 内部からも出ているため完全には消せません。本 PR のスコープ外とし、必要なら別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)