### PR TITLE
feat: Devise 5.0 へ更新する (#111)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-gem "devise"
+# 認証はメジャー更新の影響が大きいため、意図せず 6 系に上がらないよう制約をつけている
+gem "devise", "~> 5.0"
 
 gem "devise-i18n"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bcrypt (3.1.20)
+    bcrypt (3.1.22)
     bigdecimal (4.1.2)
     bindex (0.8.1)
     bootsnap (1.19.0)
@@ -112,14 +112,14 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.15.0)
-      devise (>= 4.9.0)
+    devise-i18n (1.16.0)
+      devise (>= 5.0.0)
       rails-i18n
     diff-lcs (1.6.2)
     drb (2.2.3)
@@ -147,7 +147,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.16.0)
+    json (2.21.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -409,7 +409,7 @@ DEPENDENCIES
   cssbundling-rails
   database_cleaner-active_record
   debug
-  devise
+  devise (~> 5.0)
   devise-i18n
   factory_bot_rails
   faker


### PR DESCRIPTION
Closes #111

## 概要

#100 の Rails 8.1 アップグレードで据え置いた devise を 5.0 系へ更新します。

| gem | before | after |
| --- | --- | --- |
| devise | 4.9.4 | **5.0.4** |
| devise-i18n | 1.15.0 | 1.16.0 |

## 目的

Rails 8.1 上で devise 4.9.4 を使うと、以下の deprecation warning が出ていました。

```
DEPRECATION WARNING: resource received a hash argument only. Please use a keyword instead.
Support to hash argument will be removed in Rails 8.2. (called from block in <main> at config/routes.rb:2)
```

`config/routes.rb:2` は `devise_for :users` で、**発生源は devise 4.9.4 の内部実装**のためアプリ側では解消できませんでした。
Rails 8.2 でハッシュ引数のサポートが削除されるため、それまでに必要な対応です。

**更新後、この warning は解消しています。**

## アプリ側のコード変更は不要でした

メジャーバージョン更新のため影響を警戒しましたが、変更は Gemfile / Gemfile.lock のみです。
以下を個別に確認しました。

### `config/initializers/devise.rb`

312行の設定ファイルを devise 5.0.4 に同梱されているテンプレートと突き合わせ、
**削除・改名された項目も、新規に追加された項目も無い**ことを確認しました。

```console
=== 現在の設定にあり、5.0 テンプレートに無い項目 ===
（なし）
=== 5.0 テンプレートにあり、現在の設定に無い項目 ===
（なし）
```

### 生成済みビューとカスタムコントローラー

`app/views/devise/` 配下の生成済みビュー、および #103 で `prepend_before_action :authenticate_scope!` を
入れた `Users::RegistrationsController` も、そのまま動作しています。

## Gemfile にバージョン制約を追加

```diff
-gem "devise"
+# 認証はメジャー更新の影響が大きいため、意図せず 6 系に上がらないよう制約をつけている
+gem "devise", "~> 5.0"
```

これまで無制約だったため、Dependabot が次のメジャーを提案した際にそのまま上がりうる状態でした。
今回のように破壊的変更を伴う可能性があるため、明示的に制約します。

## 確認したこと

| チェック | 結果 |
| --- | --- |
| `bundle exec rspec` | **142 examples, 0 failures** |
| `bin/rubocop` | 74 files inspected, no offenses |
| `bin/brakeman --no-pager` | Security Warnings: 0 |
| `devise_for` の deprecation warning | **解消** |

認証は spec で以下を網羅しています（いずれも通過）。

- 新規登録（有効／無効なパラメータ）
- ログイン（正しい／誤った認証情報）
- ログアウト
- パスワードリセット（申請・再設定・トークン期限切れ・パスワード不一致）
- アカウント編集の認可
- アカウント削除（正しい／誤ったパスワード、関連データの削除）

加えて、コンテナを再起動して**実際に認証画面が表示されることも確認**しました。

```
200  /users/sign_in
200  /users/sign_up
200  /users/password/new
```

## Dependabot PR #77 について

devise 4.9.4 → 5.0.0 を提案していますが、対象バージョンが古く（最新は 5.0.4）、本 PR がこれを置き換えます。
マージ後に close します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)