### PR TITLE
fix: おすすめの確からしさの置き場所と、同数のときの表現を直す (#143, #144)

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -5,15 +5,9 @@ class PreferencesController < ApplicationController
     @scope = %w[all liked].include?(params[:scope]) ? params[:scope] : "all"
     @preference = PreferenceSummary.new(current_user, scope: @scope).call
 
-    # おすすめの確からしさを表示するため、選択中のタブに関わらず両スコープを集計する。
-    # RecommendedRoast が liked / all の両方を根拠の判定に使うため（#118）。
+    # おすすめ本体も、その確からしさ・進み具合も、このページには置かない（#143）。
+    # 診断とのズレの比較相手として、★4以上の集計だけが必要。
     preference_liked = PreferenceSummary.new(current_user, scope: :liked).call
-
-    @recommended_roast = RecommendedRoast.new(
-      preference_liked: preference_liked,
-      preference_all: PreferenceSummary.new(current_user, scope: :all).call,
-      taste_profile: current_user.taste_profile
-    ).call
 
     # 診断と実際のズレ。診断は「好みの強さ」なので、比較相手は★4以上の記録（#120）
     @diagnosis_gap = DiagnosisGap.new(

--- a/app/services/preference_summary.rb
+++ b/app/services/preference_summary.rb
@@ -39,31 +39,23 @@ class PreferenceSummary
 
     # 同数の焙煎度に別々の順位を振ると、並び順だけで優劣がついたように見える。
     # 件数が同じなら同順位にする（#144）。
-    sorted_roasts = roast_counts.sort_by { |_, c| -c }
+    #
+    # 第2キーに焙煎度の定義順を入れて並びを決定づける。GROUP BY は順序を保証せず、
+    # Ruby の sort_by も同値では入力順のままなので、これが無いと同数のときの
+    # 表示順（見出しの左右・Top3 の切り出し）が実行のたびに変わりうる。
+    sorted_roasts = roast_counts.sort_by { |k, c| [ -c, roast_order(k) ] }
 
-    ranking =
-      sorted_roasts
-        .first(3)
-        .map do |k, c|
-          {
-            rank: sorted_roasts.index { |_, other| other == c } + 1,
-            label: roast_label(k),
-            percent: total.zero? ? 0 : (c / total * 100).round,
-            count: c
-          }
-        end
+    ranking = build_ranking(sorted_roasts, total)
+
+    summary_keys   = []
+    summary_labels = []
 
     if roast_logs_count.positive?
       # 件数が最多の焙煎度。同数のときは一つに絞らず全て返す。
       # 2件と2件なのに片方を「最も」と呼ぶのは事実と違うため（#144）。
-      top_keys      = top_roast_keys(roast_counts)
-      summary_keys  = top_keys.map { |k| CoffeeLog.roast_levels.key(k) || k.to_s }
+      top_keys       = top_roast_keys(sorted_roasts)
+      summary_keys   = top_keys.map { |k| CoffeeLog.roast_levels.key(k) || k.to_s }
       summary_labels = top_keys.map { |k| roast_label(k) }
-
-      # 代表の1件。同数でも一つ選ぶ必要がある箇所のために残す
-      top_key       = pick_top_roast_key(roast_counts, logs_with_roast)
-      summary_label = roast_label(top_key)
-      summary_key   = CoffeeLog.roast_levels.key(top_key) || top_key.to_s
 
       # 「よく飲んでいる」焙煎度（上の summary_*）とは別に、
       # 「評価が高い」焙煎度を出す。おすすめはこちらを根拠にする（#117）。
@@ -98,19 +90,19 @@ class PreferenceSummary
       taste_bar: taste_bar,
       ranking: ranking,
 
-      summary_roast: summary_label,
-      summary_roast_key: summary_key,
+      # 同数でない場合の1件。同数のときは見出しが summary_roast_labels を使う
+      summary_roast: summary_labels.first,
 
       # 同数の焙煎度。tied が true のとき、見出しは「同じくらい」と表現する
       summary_roast_labels: summary_labels,
       summary_roast_keys: summary_keys,
-      summary_tied: summary_keys.to_a.size > 1,
+      summary_tied: summary_keys.size > 1,
 
       # 評価が最も高い焙煎度。件数最多の summary_* とは異なりうる
       top_rated_roast: rated_label,
       top_rated_roast_key: rated_key,
       top_rated_average: rated_avg,
-      reason: summary_reason(roast_logs_count, summary_keys.to_a.size > 1),
+      reason: summary_reason(roast_logs_count, summary_keys.size > 1),
       charts_reason: scope_reason
     }
   end
@@ -124,6 +116,7 @@ class PreferenceSummary
       roast_available: false,
       roast_logs_count: 0,
       unknown_roast_count: 0,
+      summary_roast: nil,
       summary_roast_keys: [],
       summary_roast_labels: [],
       summary_tied: false,
@@ -178,10 +171,32 @@ class PreferenceSummary
     ROAST_LABELS.fetch(enum_key, enum_key)
   end
 
-  # 件数が最多の焙煎度。同数ならすべて返す。
-  def top_roast_keys(roast_counts)
-    max = roast_counts.values.max
-    roast_counts.select { |_, c| c == max }.keys
+  # 件数が最多の焙煎度。同数ならすべて返す（並び順は sorted_roasts に従う）。
+  def top_roast_keys(sorted_roasts)
+    max = sorted_roasts.first.last
+    sorted_roasts.take_while { |_, c| c == max }.map(&:first)
+  end
+
+  # Top3。ただし3位と同数のものは切り落とさない。
+  # 同順位にした以上、「同じ #1 なのに1つだけ載らない」のは説明がつかないため（#144）。
+  def build_ranking(sorted_roasts, total)
+    counts = sorted_roasts.map(&:last)
+
+    sorted_roasts.filter_map do |k, c|
+      rank = counts.index(c) + 1
+      next if rank > 3
+
+      {
+        rank: rank,
+        label: roast_label(k),
+        percent: total.zero? ? 0 : (c / total * 100).round,
+        count: c
+      }
+    end
+  end
+
+  def roast_order(key)
+    key.is_a?(Integer) ? key : CoffeeLog.roast_levels.fetch(key.to_s, 99)
   end
 
   # 平均評価が最も高い焙煎度を選ぶ。
@@ -199,15 +214,6 @@ class PreferenceSummary
 
     max_count  = candidates.map { |k| roast_counts[k].to_i }.max
     candidates = candidates.select { |k| roast_counts[k].to_i == max_count }
-    return candidates.first if candidates.size == 1
-
-    pick_latest(candidates, logs)
-  end
-
-  # 件数が同数のときは、直近で飲んだ焙煎度を優先（決め打ちでOKなMVP向け）
-  def pick_top_roast_key(roast_counts, logs)
-    max = roast_counts.values.max
-    candidates = roast_counts.select { |_, c| c == max }.keys
     return candidates.first if candidates.size == 1
 
     pick_latest(candidates, logs)

--- a/app/services/preference_summary.rb
+++ b/app/services/preference_summary.rb
@@ -37,12 +37,16 @@ class PreferenceSummary
 
     roast_pie = roast_counts.transform_keys { |k| roast_label(k) }
 
+    # 同数の焙煎度に別々の順位を振ると、並び順だけで優劣がついたように見える。
+    # 件数が同じなら同順位にする（#144）。
+    sorted_roasts = roast_counts.sort_by { |_, c| -c }
+
     ranking =
-      roast_counts
-        .sort_by { |_, c| -c }
+      sorted_roasts
         .first(3)
         .map do |k, c|
           {
+            rank: sorted_roasts.index { |_, other| other == c } + 1,
             label: roast_label(k),
             percent: total.zero? ? 0 : (c / total * 100).round,
             count: c
@@ -50,7 +54,14 @@ class PreferenceSummary
         end
 
     if roast_logs_count.positive?
-      top_key = pick_top_roast_key(roast_counts, logs_with_roast)
+      # 件数が最多の焙煎度。同数のときは一つに絞らず全て返す。
+      # 2件と2件なのに片方を「最も」と呼ぶのは事実と違うため（#144）。
+      top_keys      = top_roast_keys(roast_counts)
+      summary_keys  = top_keys.map { |k| CoffeeLog.roast_levels.key(k) || k.to_s }
+      summary_labels = top_keys.map { |k| roast_label(k) }
+
+      # 代表の1件。同数でも一つ選ぶ必要がある箇所のために残す
+      top_key       = pick_top_roast_key(roast_counts, logs_with_roast)
       summary_label = roast_label(top_key)
       summary_key   = CoffeeLog.roast_levels.key(top_key) || top_key.to_s
 
@@ -90,11 +101,16 @@ class PreferenceSummary
       summary_roast: summary_label,
       summary_roast_key: summary_key,
 
+      # 同数の焙煎度。tied が true のとき、見出しは「同じくらい」と表現する
+      summary_roast_labels: summary_labels,
+      summary_roast_keys: summary_keys,
+      summary_tied: summary_keys.to_a.size > 1,
+
       # 評価が最も高い焙煎度。件数最多の summary_* とは異なりうる
       top_rated_roast: rated_label,
       top_rated_roast_key: rated_key,
       top_rated_average: rated_avg,
-      reason: summary_reason(roast_logs_count),
+      reason: summary_reason(roast_logs_count, summary_keys.to_a.size > 1),
       charts_reason: scope_reason
     }
   end
@@ -108,6 +124,9 @@ class PreferenceSummary
       roast_available: false,
       roast_logs_count: 0,
       unknown_roast_count: 0,
+      summary_roast_keys: [],
+      summary_roast_labels: [],
+      summary_tied: false,
       scope: @scope
     }
   end
@@ -132,7 +151,11 @@ class PreferenceSummary
     end
   end
 
-  def summary_reason(roast_logs_count)
+  # 見出しの根拠。同数のときは「最も飲まれている焙煎度です」と言わない。
+  # 見出しが一つに絞らなかったのに、直下で絞ったことにすると矛盾して読めるため（#144）。
+  def summary_reason(roast_logs_count, tied)
+    return tied_reason(roast_logs_count) if tied
+
     case @scope
     when :liked
       "★4以上の評価をした記録のうち、焙煎度を記録した#{roast_logs_count}件の中で最も飲まれている焙煎度です。"
@@ -141,9 +164,24 @@ class PreferenceSummary
     end
   end
 
+  def tied_reason(roast_logs_count)
+    case @scope
+    when :liked
+      "★4以上の評価をした記録のうち、焙煎度を記録した#{roast_logs_count}件をもとにした集計です。"
+    else
+      "焙煎度を記録した#{roast_logs_count}件をもとにした集計です。"
+    end
+  end
+
   def roast_label(key)
     enum_key = key.is_a?(Integer) ? CoffeeLog.roast_levels.key(key) : key.to_s
     ROAST_LABELS.fetch(enum_key, enum_key)
+  end
+
+  # 件数が最多の焙煎度。同数ならすべて返す。
+  def top_roast_keys(roast_counts)
+    max = roast_counts.values.max
+    roast_counts.select { |_, c| c == max }.keys
   end
 
   # 平均評価が最も高い焙煎度を選ぶ。

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -35,8 +35,10 @@
 
   <!-- おすすめ焙煎度 -->
   <section class="bg-white rounded-xl shadow-sm p-6">
-    <div class="flex items-center justify-between mb-2">
-      <h2 class="text-lg font-semibold"><%= t(".sections.recommendation") %></h2>
+    <%# 根拠バッジが長く、横並びのままだと見出しが1文字ずつ折り返す。
+        狭い幅では縦に積み、見出しは縮ませない %>
+    <div class="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between mb-2">
+      <h2 class="text-lg font-semibold shrink-0"><%= t(".sections.recommendation") %></h2>
       <% if @recommended_roast&.dig(:available) %>
         <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-800">
           <%= @recommended_roast[:reason] %>
@@ -78,6 +80,11 @@
             </p>
           </div>
         </div>
+      <% end %>
+      <% if @recommended_roast[:notice].present? %>
+        <p class="text-xs text-gray-500 mt-4 leading-relaxed">
+          <%= @recommended_roast[:notice] %>
+        </p>
       <% end %>
       <div class="mt-4 flex flex-col sm:flex-row gap-3">
         <%= link_to t(".actions.record"),
@@ -123,7 +130,14 @@
 
         <% if @preference_all[:roast_available] %>
           <p class="text-base font-semibold text-amber-800">
-            <%= t(".insights.summary_roast", roast: @preference_all[:summary_roast]) %>
+            <% labels = @preference_all[:summary_roast_labels] %>
+            <% if !@preference_all[:summary_tied] %>
+              <%= t(".insights.summary_roast", roast: @preference_all[:summary_roast]) %>
+            <% elsif labels.size == 2 %>
+              <%= t(".insights.summary_roast_tied_two", first: labels.first, second: labels.second) %>
+            <% else %>
+              <%= t(".insights.summary_roast_tied_many") %>
+            <% end %>
           </p>
           <p class="text-xs text-gray-500">
             <%= t(".insights.target_count", count: @preference_all[:roast_logs_count]) %>
@@ -160,7 +174,14 @@
 
         <% if @preference_liked[:roast_available] %>
           <p class="text-base font-semibold text-amber-800">
-            <%= t(".insights.summary_roast", roast: @preference_liked[:summary_roast]) %>
+            <% labels = @preference_liked[:summary_roast_labels] %>
+            <% if !@preference_liked[:summary_tied] %>
+              <%= t(".insights.summary_roast", roast: @preference_liked[:summary_roast]) %>
+            <% elsif labels.size == 2 %>
+              <%= t(".insights.summary_roast_tied_two", first: labels.first, second: labels.second) %>
+            <% else %>
+              <%= t(".insights.summary_roast_tied_many") %>
+            <% end %>
           </p>
           <p class="text-xs text-gray-500">
             <%= t(".insights.target_count", count: @preference_liked[:roast_logs_count]) %>
@@ -186,13 +207,8 @@
       </div>
     </div>
 
-    <%# 補足メッセージ（おすすめの確からしさ）と、次の段階までの進み具合 %>
-    <% if @recommended_roast[:notice].present? %>
-      <p class="text-xs text-gray-500 mt-4 leading-relaxed">
-        <%= @recommended_roast[:notice] %>
-      </p>
-    <% end %>
-
+    <%# 次の段階までの進み具合。おすすめの確からしさ（notice）は、
+        何を修飾しているか分かるようおすすめカード側に置いている（#143） %>
     <% if @recommended_roast[:progress].present? %>
       <div class="mt-4">
         <%= render "shared/recommendation_progress", progress: @recommended_roast[:progress] %>

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -45,14 +45,6 @@
       </div>
     <% end %>
 
-    <%# 進捗はサマリーカードの有無に関わらず出す。カード内に置くと、
-        焙煎度の傾向が出せない状態のときだけ進捗も消えてしまう %>
-    <% if @recommended_roast[:progress].present? %>
-      <div class="rounded-xl border bg-white p-6 shadow-sm">
-        <%= render "shared/recommendation_progress", progress: @recommended_roast[:progress] %>
-      </div>
-    <% end %>
-
     <div class="grid md:grid-cols-2 gap-6">
       <!-- 焙煎度（円グラフ） -->
       <div class="rounded-xl border bg-white p-6 shadow-sm wrapper w-full overflow-hidden">

--- a/app/views/preferences/show.html.erb
+++ b/app/views/preferences/show.html.erb
@@ -27,19 +27,21 @@
       <div class="rounded-xl border bg-white p-6 shadow-sm space-y-2">
         <% summary_suffix_key = (@scope == "liked") ? "liked" : "all" %>
         <p class="text-lg font-semibold text-amber-800">
-          <%= t(".summary.text", roast: @preference[:summary_roast], suffix: t(".summary.suffix.#{summary_suffix_key}")) %>
+          <% labels = @preference[:summary_roast_labels] %>
+          <% if !@preference[:summary_tied] %>
+            <%= t(".summary.text", roast: @preference[:summary_roast],
+                  suffix: t(".summary.suffix.#{summary_suffix_key}")) %>
+          <% elsif labels.size == 2 %>
+            <%= t(".summary.tied_two", first: labels.first, second: labels.second,
+                  suffix: t(".summary.suffix_tied.#{summary_suffix_key}")) %>
+          <% else %>
+            <%= t(".summary.tied_many", suffix: t(".summary.suffix_tied.#{summary_suffix_key}")) %>
+          <% end %>
         </p>
 
         <p class="text-sm text-gray-600">
           <%= @preference[:reason] %>
         </p>
-
-        <% if @recommended_roast[:notice].present? %>
-          <p class="text-xs text-gray-500">
-            <%= @recommended_roast[:notice] %>
-          </p>
-        <% end %>
-
       </div>
     <% end %>
 
@@ -96,10 +98,11 @@
       <h2 class="text-lg font-semibold mb-4"><%= t(".ranking.title") %></h2>
 
       <div class="space-y-3">
-        <% @preference[:ranking].each_with_index do |item, idx| %>
+        <% @preference[:ranking].each do |item| %>
           <div class="flex items-center justify-between rounded-lg border p-4">
             <div>
-              <p class="text-sm text-gray-500">#<%= idx + 1 %></p>
+              <%# 同数なら同じ順位。並び順で優劣がついたように見せない（#144） %>
+              <p class="text-sm text-gray-500">#<%= item[:rank] %></p>
               <p class="text-lg font-semibold text-gray-900"><%= item[:label] %></p>
               <p class="text-sm text-gray-600">
                 <%= t(".ranking.row", percent: item[:percent], count: item[:count]) %>
@@ -113,11 +116,6 @@
         <%= t(".ranking.note") %>
       </p>
     </div>
-    <% elsif @recommended_roast[:notice].present? %>
-      <%# サマリーカードを出していないぶん、おすすめの確からしさはここで伝える %>
-      <p class="text-xs text-gray-500 leading-relaxed">
-        <%= @recommended_roast[:notice] %>
-      </p>
     <% end %>
   <% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -175,6 +175,9 @@ ja:
         all_title: "全ての記録"
         liked_title: "好評価(★4以上)"
         summary_roast: "「%{roast}」が多い傾向です"
+        # 件数が同数のときは片方を「多い」と呼ばない（#144）
+        summary_roast_tied_two: "「%{first}」と「%{second}」が同じくらいです"
+        summary_roast_tied_many: "いくつかの焙煎度が同じくらいです"
         target_count: "対象：%{count}件（件数ベース）"
         empty_all: "まだ傾向を表示できる記録がありません。"
         empty_liked: "★4以上の記録がまだありません。お気に入りに★4以上を付けると「好き」が見えてきます。"
@@ -321,9 +324,15 @@ ja:
       # 「好み」の判定はおすすめ側（評価ベース）が担うため、ここで好みを主張しない（#117）
       summary:
         text: "あなたは「%{roast}」のコーヒーを %{suffix}。"
+        # 件数が同数のときは、片方を「最も」と呼ばない（#144）
+        tied_two: "「%{first}」と「%{second}」を %{suffix}。"
+        tied_many: "いくつかの焙煎度を %{suffix}。"
         suffix:
           all: "よく飲んでいます"
           liked: "★4以上をつけた記録の中で、いちばん多く飲んでいます"
+        suffix_tied:
+          all: "同じくらい飲んでいます"
+          liked: "★4以上をつけた記録の中で、同じくらい飲んでいます"
 
       charts:
         roast:

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -50,6 +50,45 @@ RSpec.describe "Mypage", type: :request do
             )
           )
         end
+
+        # #143 確からしさは、それが修飾するおすすめの近くに置く
+        it "おすすめの確からしさが、おすすめカードの中に表示されること" do
+          get mypage_path
+
+          notice_at   = response.body.index(
+            ERB::Util.html_escape(I18n.t("services.recommended_roast.notice.likely", count: 4))
+          )
+          insights_at = response.body.index(I18n.t("mypage.show.sections.insights"))
+
+          expect(notice_at).to be_present
+          expect(notice_at).to be < insights_at
+        end
+      end
+
+
+      # #144 件数が同数のとき、片方を「多い」と呼ばない
+      context "最も飲んでいる焙煎度が同数の場合" do
+        before do
+          2.times { create(:coffee_log, :light_roast, user: user, overall_rating: 4) }
+          2.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 4) }
+        end
+
+        it "同じくらいであることを伝えること" do
+          get mypage_path
+          expect(response.body).to include(
+            ERB::Util.html_escape(
+              I18n.t("mypage.show.insights.summary_roast_tied_two", first: "浅煎り", second: "深煎り")
+            )
+          )
+        end
+
+        it "/preferences と同じ判断になること" do
+          # 片方だけ直すと画面間で食い違う
+          get mypage_path
+          expect(response.body).not_to include(
+            ERB::Util.html_escape(I18n.t("mypage.show.insights.summary_roast", roast: "浅煎り"))
+          )
+        end
       end
 
       context "焙煎度が全て不明の記録しかない場合" do

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -82,11 +82,13 @@ RSpec.describe "Mypage", type: :request do
           )
         end
 
-        it "/preferences と同じ判断になること" do
-          # 片方だけ直すと画面間で食い違う
+        it "片方を「多い傾向」とは表示しないこと" do
           get mypage_path
           expect(response.body).not_to include(
             ERB::Util.html_escape(I18n.t("mypage.show.insights.summary_roast", roast: "浅煎り"))
+          )
+          expect(response.body).not_to include(
+            ERB::Util.html_escape(I18n.t("mypage.show.insights.summary_roast", roast: "深煎り"))
           )
         end
       end

--- a/spec/requests/preferences_spec.rb
+++ b/spec/requests/preferences_spec.rb
@@ -33,24 +33,31 @@ RSpec.describe "Preferences", type: :request do
 
 
 
-      # #143 おすすめの確からしさはマイページに集約する
-      context "おすすめの確からしさ" do
+      # #143 おすすめに関する表示はマイページに集約する
+      context "おすすめの確からしさと進み具合" do
         before do
           create(:taste_profile, user: user)
           4.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 5) }
         end
 
-        it "/preferences には表示しないこと" do
+        it "確からしさを表示しないこと" do
           get preferences_path
           expect(response.body).not_to include(
             ERB::Util.html_escape(I18n.t("services.recommended_roast.notice.likely", count: 4))
           )
         end
 
-        it "進捗バーは残ること" do
-          # 分子は「焙煎度を記録した件数」で、見出しの根拠と一致するため矛盾しない
+        it "進み具合も表示しないこと" do
+          # 「あと N 件でおすすめを出せます」もおすすめの話。
+          # おすすめ本体が無いページに置くと、直前の見出しの説明に読める
           get preferences_path
-          expect(response.body).to include(I18n.t("services.recommended_roast.progress.label.likely"))
+          expect(response.body).not_to include(I18n.t("services.recommended_roast.progress.label.likely"))
+        end
+
+        it "★4以上タブでも表示しないこと" do
+          # 進み具合の分子は全記録ベースで、このタブの「3件」とは意味が違う
+          get preferences_path(scope: "liked")
+          expect(response.body).not_to include(I18n.t("services.recommended_roast.progress.label.likely"))
         end
       end
 
@@ -72,47 +79,14 @@ RSpec.describe "Preferences", type: :request do
         end
 
         it "同じくらい飲んでいることを伝えること" do
-          get preferences_path
-          expect(response.body).to include(
-            ERB::Util.html_escape(I18n.t("preferences.show.summary.suffix_tied.all"))
-          )
-          expect(response.body).to include("浅煎り")
-          expect(response.body).to include("深煎り")
-        end
-      end
-
-      # #122 次の段階までの進み具合
-      context "実データを根拠にしているが安定していない場合" do
-        before do
-          create(:taste_profile, user: user)
-          4.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 5) }
-        end
-
-        it "安定するまでの残り件数が表示されること" do
+          # 焙煎度名はランキングにも出るため、見出しの文ごと突き合わせる
           get preferences_path
           expect(response.body).to include(
             ERB::Util.html_escape(
-              I18n.t("services.recommended_roast.progress.remaining.likely", count: 6)
+              I18n.t("preferences.show.summary.tied_two", first: "浅煎り", second: "深煎り",
+                     suffix: I18n.t("preferences.show.summary.suffix_tied.all"))
             )
           )
-        end
-
-        it "現在地が分かること" do
-          get preferences_path
-          expect(response.body).to include("4 / #{RecommendedRoast::STABLE_MIN}")
-        end
-      end
-
-      context "記録を増やしても段階が進まない場合" do
-        before do
-          create(:taste_profile, user: user)
-          # 低評価ばかりで、件数を増やしても実データを根拠にできない
-          10.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 2) }
-        end
-
-        it "残り件数を約束しないこと" do
-          get preferences_path
-          expect(response.body).not_to include(I18n.t("services.recommended_roast.progress.label.hypothesis"))
         end
       end
 

--- a/spec/requests/preferences_spec.rb
+++ b/spec/requests/preferences_spec.rb
@@ -32,6 +32,55 @@ RSpec.describe "Preferences", type: :request do
 
 
 
+
+      # #143 おすすめの確からしさはマイページに集約する
+      context "おすすめの確からしさ" do
+        before do
+          create(:taste_profile, user: user)
+          4.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 5) }
+        end
+
+        it "/preferences には表示しないこと" do
+          get preferences_path
+          expect(response.body).not_to include(
+            ERB::Util.html_escape(I18n.t("services.recommended_roast.notice.likely", count: 4))
+          )
+        end
+
+        it "進捗バーは残ること" do
+          # 分子は「焙煎度を記録した件数」で、見出しの根拠と一致するため矛盾しない
+          get preferences_path
+          expect(response.body).to include(I18n.t("services.recommended_roast.progress.label.likely"))
+        end
+      end
+
+      # #144 件数が同数のとき
+      context "最も飲んでいる焙煎度が同数の場合" do
+        before do
+          2.times { create(:coffee_log, :light_roast, user: user, overall_rating: 2) }
+          2.times { create(:coffee_log, :dark_roast, user: user, overall_rating: 5) }
+        end
+
+        it "片方を「最も飲んでいる」とは表示しないこと" do
+          get preferences_path
+          expect(response.body).not_to include(
+            ERB::Util.html_escape(
+              I18n.t("preferences.show.summary.text", roast: "浅煎り",
+                     suffix: I18n.t("preferences.show.summary.suffix.all"))
+            )
+          )
+        end
+
+        it "同じくらい飲んでいることを伝えること" do
+          get preferences_path
+          expect(response.body).to include(
+            ERB::Util.html_escape(I18n.t("preferences.show.summary.suffix_tied.all"))
+          )
+          expect(response.body).to include("浅煎り")
+          expect(response.body).to include("深煎り")
+        end
+      end
+
       # #122 次の段階までの進み具合
       context "実データを根拠にしているが安定していない場合" do
         before do
@@ -203,14 +252,15 @@ RSpec.describe "Preferences", type: :request do
           expect(response.body).not_to include(I18n.t("preferences.show.summary.suffix.all"))
         end
 
-        it "焙煎度の傾向が出せない以上、おすすめが安定しているとは表示しないこと" do
+        it "おすすめの確からしさは表示しないこと" do
+          # おすすめ本体はこのページに無い。確からしさだけ置くと、
+          # すぐ上の見出しを修飾しているように読める（#143）
           create(:taste_profile, user: user)
           get preferences_path
 
-          expect(response.body).to include(
+          expect(response.body).not_to include(
             I18n.t("services.recommended_roast.notice.hypothesis")
           )
-          expect(response.body).not_to include("安定しています")
         end
       end
 

--- a/spec/services/preference_summary_spec.rb
+++ b/spec/services/preference_summary_spec.rb
@@ -173,4 +173,82 @@ RSpec.describe PreferenceSummary do
       expect(described_class.new(user).call[:top_rated_roast_key]).to eq "dark"
     end
   end
+
+  # #144 件数が同数のときは、片方を「最も」と呼ばない
+  describe "最も飲んでいる焙煎度が一つに定まらない場合" do
+    it "同数の焙煎度をすべて返すこと" do
+      2.times { log(roast: :light, rating: 2) }
+      2.times { log(roast: :dark,  rating: 5) }
+      1.times { log(roast: :medium_dark, rating: 4) }
+      result = described_class.new(user).call
+
+      expect(result[:summary_roast_keys]).to contain_exactly("light", "dark")
+      expect(result[:summary_tied]).to be true
+    end
+
+    it "同数が3つ以上でもすべて返すこと" do
+      %i[light medium dark].each { |r| log(roast: r, rating: 4) }
+      result = described_class.new(user).call
+
+      expect(result[:summary_roast_keys].size).to eq 3
+      expect(result[:summary_tied]).to be true
+    end
+
+    it "一つに定まる場合は同数扱いにしないこと" do
+      3.times { log(roast: :dark,  rating: 5) }
+      1.times { log(roast: :light, rating: 5) }
+      result = described_class.new(user).call
+
+      expect(result[:summary_roast_keys]).to eq [ "dark" ]
+      expect(result[:summary_tied]).to be false
+      expect(result[:summary_roast_key]).to eq "dark"
+    end
+
+    it "同数でも記録日が違えば、直近に飲んだ方を代表とすること" do
+      # 既存の summary_roast_key は後方互換のため残す
+      log(roast: :light, rating: 4, drank_on: Date.current - 10)
+      log(roast: :light, rating: 4, drank_on: Date.current - 10)
+      log(roast: :dark,  rating: 4, drank_on: Date.current)
+      log(roast: :dark,  rating: 4, drank_on: Date.current)
+      result = described_class.new(user).call
+
+      expect(result[:summary_roast_key]).to eq "dark"
+      expect(result[:summary_tied]).to be true
+    end
+
+    it "「最も飲まれている焙煎度です」とは説明しないこと" do
+      2.times { log(roast: :light, rating: 2) }
+      2.times { log(roast: :dark,  rating: 5) }
+      result = described_class.new(user).call
+
+      expect(result[:reason]).not_to include "最も飲まれている"
+      expect(result[:reason]).to include "4件"
+    end
+
+    it "同数でなければ従来どおり「最も飲まれている」と説明すること" do
+      3.times { log(roast: :dark,  rating: 5) }
+      1.times { log(roast: :light, rating: 5) }
+      result = described_class.new(user).call
+
+      expect(result[:reason]).to include "最も飲まれている"
+    end
+
+    it "ランキングでは同数の焙煎度を同順位にすること" do
+      2.times { log(roast: :light, rating: 2) }
+      2.times { log(roast: :dark,  rating: 5) }
+      1.times { log(roast: :medium_dark, rating: 4) }
+      ranks = described_class.new(user).call[:ranking].map { |r| r[:rank] }
+
+      expect(ranks).to eq [ 1, 1, 3 ]
+    end
+
+    it "同数でなければ順位は連番になること" do
+      3.times { log(roast: :dark,  rating: 5) }
+      2.times { log(roast: :light, rating: 5) }
+      1.times { log(roast: :medium, rating: 5) }
+      ranks = described_class.new(user).call[:ranking].map { |r| r[:rank] }
+
+      expect(ranks).to eq [ 1, 2, 3 ]
+    end
+  end
 end

--- a/spec/services/preference_summary_spec.rb
+++ b/spec/services/preference_summary_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe PreferenceSummary do
 
     it "最も件数の多い焙煎度をサマリーとすること" do
       result = described_class.new(user).call
-      expect(result[:summary_roast_key]).to eq "light"
+      expect(result[:summary_roast_keys]).to eq [ "light" ]
     end
 
     it "焙煎度の円グラフに全ての焙煎度が含まれること" do
@@ -44,7 +44,7 @@ RSpec.describe PreferenceSummary do
       it "★4以上の記録だけを集計すること" do
         result = described_class.new(user, scope: :liked).call
         expect(result[:logs_count]).to eq 3
-        expect(result[:summary_roast_key]).to eq "light"
+        expect(result[:summary_roast_keys]).to eq [ "light" ]
       end
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe PreferenceSummary do
         result = described_class.new(user).call
         expect(result[:roast_available]).to be false
         expect(result[:roast_logs_count]).to eq 0
-        expect(result[:summary_roast_key]).to be_nil
+        expect(result[:summary_roast_keys]).to eq []
       end
     end
 
@@ -95,7 +95,7 @@ RSpec.describe PreferenceSummary do
         result = described_class.new(user).call
         expect(result[:roast_available]).to be true
         expect(result[:roast_logs_count]).to eq 3
-        expect(result[:summary_roast_key]).to eq "light"
+        expect(result[:summary_roast_keys]).to eq [ "light" ]
       end
 
       it "円グラフに「不明」を含めないこと" do
@@ -136,7 +136,7 @@ RSpec.describe PreferenceSummary do
       2.times { log(roast: :light, rating: 5) }
       result = described_class.new(user).call
 
-      expect(result[:summary_roast_key]).to eq "dark"     # よく飲んでいるのは深煎り
+      expect(result[:summary_roast_keys]).to eq [ "dark" ] # よく飲んでいるのは深煎り
       expect(result[:top_rated_roast_key]).to eq "light"  # 評価が高いのは浅煎り
       expect(result[:top_rated_average]).to eq 5.0
     end
@@ -201,19 +201,60 @@ RSpec.describe PreferenceSummary do
 
       expect(result[:summary_roast_keys]).to eq [ "dark" ]
       expect(result[:summary_tied]).to be false
-      expect(result[:summary_roast_key]).to eq "dark"
+      expect(result[:summary_roast]).to eq "深煎り"
     end
 
-    it "同数でも記録日が違えば、直近に飲んだ方を代表とすること" do
-      # 既存の summary_roast_key は後方互換のため残す
+    it "記録日が違っても、同数なら片方を代表にしないこと" do
+      # 記録日で決める旧タイブレークは廃止した。同じ日に複数杯を記録すると
+      # 決着せず、実質 enum の定義順で決まってしまうため（#144）
       log(roast: :light, rating: 4, drank_on: Date.current - 10)
       log(roast: :light, rating: 4, drank_on: Date.current - 10)
       log(roast: :dark,  rating: 4, drank_on: Date.current)
       log(roast: :dark,  rating: 4, drank_on: Date.current)
       result = described_class.new(user).call
 
-      expect(result[:summary_roast_key]).to eq "dark"
+      expect(result[:summary_roast_keys]).to eq [ "light", "dark" ]
       expect(result[:summary_tied]).to be true
+    end
+
+    it "同数の並び順が焙煎度の定義順で決まること" do
+      # GROUP BY は順序を保証しない。見出しの左右が実行のたびに入れ替わらないよう固定する
+      log(roast: :dark,  rating: 4)
+      log(roast: :light, rating: 4)
+
+      2.times do
+        expect(described_class.new(user).call[:summary_roast_labels]).to eq [ "浅煎り", "深煎り" ]
+      end
+    end
+
+    it "3位と同数の焙煎度をランキングから切り落とさないこと" do
+      # 同順位にした以上、「同じ #1 なのに1件だけ載らない」のは説明がつかない
+      %i[light medium medium_dark dark].each { |r| log(roast: r, rating: 4) }
+      ranking = described_class.new(user).call[:ranking]
+
+      expect(ranking.map { |r| r[:rank] }).to eq [ 1, 1, 1, 1 ]
+      expect(ranking.map { |r| r[:label] }).to include "深煎り"
+    end
+
+    it "3位が同数なら、4件目も同じ順位で載せること" do
+      3.times { log(roast: :dark, rating: 4) }
+      2.times { log(roast: :light, rating: 4) }
+      1.times { log(roast: :medium, rating: 4) }
+      1.times { log(roast: :medium_dark, rating: 4) }
+      ranking = described_class.new(user).call[:ranking]
+
+      expect(ranking.map { |r| r[:rank] }).to eq [ 1, 2, 3, 3 ]
+    end
+
+    it "4位が同数でなければ、従来どおり3件で打ち切ること" do
+      4.times { log(roast: :dark, rating: 4) }
+      3.times { log(roast: :light, rating: 4) }
+      2.times { log(roast: :medium, rating: 4) }
+      1.times { log(roast: :medium_dark, rating: 4) }
+      ranking = described_class.new(user).call[:ranking]
+
+      expect(ranking.map { |r| r[:rank] }).to eq [ 1, 2, 3 ]
+      expect(ranking.map { |r| r[:label] }).not_to include "中深煎り"
     end
 
     it "「最も飲まれている焙煎度です」とは説明しないこと" do


### PR DESCRIPTION
Closes #143
Closes #144

## #143 `/preferences` から、そのページに無いものの説明を外す

「記録3件をもとにした暫定の傾向です。記録が増えると変わることがあります。」は
**おすすめの確からしさ**を述べる文だが、`/preferences` におすすめは表示されていない。
すぐ上の「最も飲んでいる焙煎度」の見出しを修飾しているように読めていた。

- `/preferences` の2箇所（サマリーカード内・ランキングが出ないときの代替位置）から削除
- **進捗バーも同じ理由で外した。** 文言が「あと3件記録すると、あなたの記録から
  **おすすめ**を出せるようになります」「診断からの予想」で、おすすめの段階を説明している。
  さらに★4以上タブでは、直前の見出しが「3件の中で」と言っているのに分子が5（全記録ベース）で、
  意味の違う「N件」が並ぶという #143 そのものの状態になっていた
- 使われなくなった `@recommended_roast` を `PreferencesController` から削除（集計3回分減る）
- マイページでは、傾向カードの下ではなく**おすすめカードの中**に移した。
  移す前は「おすすめ」と「確からしさ」の間に傾向カードが挟まっており、
  何を修飾しているのか同じように読み取れなかった

結果として、おすすめに関する表示はすべてマイページに集約された。

## #144 同数のときに、説明できない基準で片方を選ばない

深煎り2件・浅煎り2件でも「深煎り」が選ばれていた。
`pick_top_roast_key` は同数のとき最終記録日で比べるが、同じ日に記録すると
`maximum(:drank_on)` が同値になり、実質 **enum の定義順**で決まっていた。
1人で複数杯を同じ日に記録するのは普通なので、表に出やすい状態だった。

`PreferenceSummary` が同数の焙煎度をすべて返し、表示側で「同じくらい」と言い換える。

| データ | 表示 |
| --- | --- |
| 深煎り2・浅煎り2・中深煎り1 | 「浅煎り」と「深煎り」を 同じくらい飲んでいます。 |
| 深煎り3・浅煎り1 | あなたは「深煎り」のコーヒーを よく飲んでいます。 |
| 浅煎り1・中煎り1・深煎り1 | いくつかの焙煎度を 同じくらい飲んでいます。 |

**マイページも同じ問題を抱えていた**ため、あわせて直した。片方だけ直すと
「マイページでは浅煎りが多い」「`/preferences` では同じくらい」という画面間の矛盾になる。

原因だった `pick_top_roast_key` は削除した。参照元が無くなったのに残すと、
将来同じタイブレークを拾って再発させる導線になるため。あわせて `summary_roast_key`
（アプリ側の参照なし）も落とし、`summary_roast` は同数でない場合の1件を返す。

### 見出しの根拠文とランキングも揃えた

見出しが一つに絞らないのに、直下の根拠文が「最も飲まれている焙煎度です」のままだと
絞ったことになるため、同数のときは「焙煎度を記録した5件をもとにした集計です。」に変える。

ランキングも同じ問題があった。40%・2件が2つ並んでいるのに `#1` `#2` と振られ、
並び順だけで優劣がついたように見えていた。同数は同順位（`#1` `#1` `#3`）にする。

## レビューでの指摘と対応

サブエージェントのレビューで挙がった指摘。再現を確認したうえで判断した。

### 取り込んだもの

| 指摘 | 対応 |
| --- | --- |
| 同数の**並び順**が `GROUP BY` の非保証な順序に依存している。見出しの左右と Top3 の切り出しが実行のたびに変わりうる | 焙煎度の定義順を第2キーにして決定づけた。`sort_by` は同値では入力順のままなので、これが無いと固定できない |
| 同順位にしたことで、3位と同数の焙煎度が Top3 から**説明なく消える**（4種同数だと `#1 #1 #1` で1つ欠ける） | 3位と同数のものは切り落とさないようにした |
| ★4以上タブで、進捗バーの分子と見出しの件数が食い違う | 進捗バーごと `/preferences` から外した（上記 #143） |
| PR 本文の「すぐ上に出ている『対象：5件』と一致」が誤り。`対象：N件` はマイページの文言で、`/preferences` には存在しない | 本文を修正。根拠が成立していなかったので、結論（残す）も撤回した |
| 見出しの「AとB」が spec で固定できていない。焙煎度名はランキングにも出るため `include("浅煎り")` では壊れても通る | `tied_two` の文ごと突き合わせるようにした |
| 焙煎度が全て不明のとき `summary_roast_labels` が経路によって `nil` / `[]` に割れる | `[]` で初期化した |
| `summary_roast_key` に呼び出し元がいない | `pick_top_roast_key` ごと削除 |
| `spec/requests/mypage_spec.rb` の「/preferences と同じ判断になること」が `/preferences` を見ていない | 実際に検証している内容に名前を合わせた |

### 取り込まなかったもの

**おすすめ側の同点が未対応（レビュー指摘8）** — 平均評価が完全同点でも
「評価が最も高い」と断定する。同じ構造の問題だが、おすすめは性質上ひとつ選ぶ必要があり、
「同数なら併記」がそのまま使えるとは限らない。設計判断が要るため #146 に切り出した。

## スマートフォン幅（390px）で確認したこと

`/preferences`（全記録／★4以上）と `/mypage` を iframe 内 390px で描画して確認した。
横スクロールなし・はみ出し要素0件。

確認中に、マイページの「おすすめ」見出しが**1文字ずつ折り返していた**のを見つけたので直した。
根拠バッジ（「好評価の記録の中で評価が最も高い（3件をもとに）」）が長く、
`flex ... justify-between` で横並びのまま押されていた。狭い幅では縦に積み、見出しは縮ませない。
これは本 Issue 以前からあった崩れ。

## テスト

260 examples, 0 failures / RuboCop 79 files no offenses / Brakeman no warnings

追加した spec は変異テストで確認済み。

| 壊した箇所 | 落ちた spec |
| --- | --- |
| 同数でも `tied_reason` を使わないようにする | 1件 |
| `rank` を連番に戻す | 1件 |
| 確からしさをおすすめカードの外に戻す | 1件 |
| 並び順の第2キー（定義順）を逆にする | 4件 |
| Top3 を同順位ごと切り落とすように戻す | 2件 |
| 見出しの `labels.size == 2` 分岐を潰す | 1件 |
| 進捗バーを `/preferences` に戻す | 2件 |

## 積み残し

`PreferenceSummary#summary_reason` などの日本語が Ruby に直書きのままになっている。
CLAUDE.md は「ビューに日本語を直接書かない」としており、サービスも同じ扱いが望ましいが、
このファイル全体の話になりスコープ外のため今回は既存の書き方に揃えた。
