### PR TITLE
fix: puma のバインド先を 0.0.0.0 に明示する (#114)

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,7 +24,17 @@ threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+#
+# ホスト `0.0.0.0` は明示する。Puma 8 は非ループバックの IPv6 インターフェースがある環境では
+# 既定のバインド先が `::` になり、無ければ `0.0.0.0` に戻る（実行環境で変わる）。
+# Render は「web サービスは 0.0.0.0 にバインドすること」を要件としているため、環境任せにしない。
+#
+# ここが効くのは `bundle exec puma` で直接起動した場合と、`bin/rails server` に
+# `-b`/`-p` も `PORT`/`HOST`/`BINDING` も与えられていない場合。それらがあると
+# Rails 側のホスト（本番は 0.0.0.0）で bind が上書きされ、この指定は使われない。
+# Render は PORT を必ず設定するため、起動が `bin/rails server` なら実質 no-op になる。
+# 起動方法によらず 0.0.0.0 にするための保険として置いている。
+port ENV.fetch("PORT", 3000), "0.0.0.0"
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
`config/puma.rb` のバインド先を `0.0.0.0` に明示する（#114）。

## この PR の範囲が変わりました

当初は puma 7.2.1 → 8.0.2 の更新も含んでいましたが、**Dependabot の #132 が先にマージされ、
`main` はすでに puma 8.0.2 になりました**（`d745594`）。重複して競合したため、
`Gemfile` / `Gemfile.lock` のコミットを落とし、**`config/puma.rb` の1ファイルだけ**にしています。

#114 のチェックリストのうち、`Gemfile` の制約更新は #132 で済んでいます。

## なぜ必要か

[Puma 8.0 Upgrade Guide](https://github.com/puma/puma/blob/v8.0.2/docs/8.0-Upgrade.md) の破壊的変更の1項目目:

> Puma will now listen on `::` (IPv6) by default. Previously, it listened to `0.0.0.0` (IPv4).
> Systems that support both IPv6 and IPv4 (Ubuntu and Mac commonly do) will still support
> receiving to `0.0.0.0`.

`config/puma.rb` はホストを指定していないため、**バインド先が実行環境しだいで変わります**。
Render の要件は次のとおりです。

> Every Render web service must bind to a port on host `0.0.0.0` to serve HTTP requests.
> （[Render Docs / Web Services](https://render.com/docs/web-services)）

Upgrade Guide が挙げている IPv4 固定の書き方（`port ENV.fetch('PORT', 9292), '0.0.0.0'`）を採用しました。

## 効く場面は限られます

本番用 Dockerfile を、**非ループバック IPv6 を持つ Docker ネットワーク**上で
`RAILS_ENV=production` として起動した実測結果。設定が効いているかを判定するため、
ホストに `127.0.0.1` を書いた「番人」でも測っています。

| 起動方法 | `PORT` | 指定なし（変更前） | `"0.0.0.0"`（変更後） | 番人 `"127.0.0.1"` |
| --- | --- | --- | --- | --- |
| `bin/rails server` | なし | `0.0.0.0:3000` | `0.0.0.0:3000` | **`127.0.0.1:3000`** |
| `bin/rails server` | `10000` | `0.0.0.0:10000` | `0.0.0.0:10000` | `0.0.0.0:10000` |
| `bundle exec puma` | `10000` | **`[::]:10000`** | `0.0.0.0:10000` | `127.0.0.1:10000` |

番人の列が判定材料です。`bin/rails server` は **`-b`/`-p` か `PORT`/`HOST`/`BINDING` が
与えられたときだけ** Rails 側のホストで bind を上書きします。

Render は `PORT` を必ず設定する（既定 10000）ため、

- **Docker 経路 / `bin/rails server` 起動** → 表の2行目。変更前から `0.0.0.0` で、**この変更は no-op**
- **`bundle exec puma` 起動** → 表の3行目。変更が無いと `[::]` になりうるので**有効に効く**

**起動方法によらず `0.0.0.0` になるようにする保険**として入れています。

なお `::` にバインドされた場合も、コンテナの `net.ipv6.bindv6only` が `0` のため
IPv4 の接続自体は届いていました。**即座に落ちるとは限りません。**

## 開発環境への副作用

ポートを指定しない `bin/rails server`（開発環境）のバインド先が変わります。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `bin/rails server`（開発・ポート指定なし） | `127.0.0.1:3000` と `[::1]:3000` の2つ | `0.0.0.0:3000` の1つ |

`Procfile.dev` は元々 `bin/rails server -b 0.0.0.0 -p 3000` と明示しており、
開発は Docker 前提のため `bin/dev` 経由の挙動は変わりません。
影響するのはホスト機で直接 `rails s` を叩く場合だけです。

環境で分岐させる案も検討しましたが、`RAILS_ENV` 未設定の本番で `localhost` にバインドすると
今より悪い壊れ方をします。デプロイに直結するファイルなので**単純さを優先**しました。

## Puma 8 の破壊的変更とこのアプリの関係

Upgrade Guide の「Upgrade」7項目を確認しました。該当するのは1項目目だけです。

| # | 変更内容 | このアプリ |
| --- | --- | --- |
| 1 | 既定バインドが `::` に | **該当** → この PR で対処 |
| 2 | 明示的な `::` 指定が、非ループバック IPv6 が無いホストでは `0.0.0.0` に書き換わる | 指定なし |
| 3 | `before_thread_start` が引数を受け取る | 未使用 |
| 4 | `SIGINFO` の無いプラットフォームで `SIGPWR` を捕捉する | 配線なし |
| 5 | `supported_http_methods` の扱いが変わる | 未使用 |
| 6 | `http_content_length_limit` が厳格化 | 未設定・大きな送信なし |
| 7 | `fork_worker` の phased restart 順が変わる | 未使用 |

### `WEB_CONCURRENCY`（#114 のチェック項目）

**7.2.1 と 8.0.2 で扱いは変わりません。** どちらも puma 本体が `ENV['WEB_CONCURRENCY']` を読むため、
`config/puma.rb` に `workers` を書いていなくても、この環境変数があれば cluster mode になります
（両バージョンの `Puma::Configuration#puma_options_from_env` は完全に同一）。
今回の更新による変化はありません。

## 検証

- 本番用イメージをビルドし、IPv6 の有無を作り分けたネットワークで起動して上表を実測
- `bundle exec rspec` 300 examples, 0 failures / `bin/rubocop` no offenses

## 未確認

- 実際の Render 上での挙動。デプロイは #156 で行うため、そちらのログで
  `Puma version:` と `Listening on` を確認します

## 切り戻し

`config/puma.rb` の1ファイルのみなので `git revert` で戻せます。
