### PR TITLE
fix: 診断結果の見出しが狭い幅で1文字だけ折り返すのを直す (#158)

### DIFF
--- a/app/views/taste_profiles/show.html.erb
+++ b/app/views/taste_profiles/show.html.erb
@@ -12,9 +12,8 @@
 
 
 <div class="max-w-3xl mx-auto py-10 px-4">
-  <%# 390px では text-2xl だと 335px 必要で、使える幅 326px に収まらず「果」だけが
-      次の行に落ちる。狭い幅でだけ1段階小さくして1行に収める（#158）。
-      text-balance も試したが、「コーヒ / ー」と長音符が行頭に来るため採らなかった %>
+  <%# 狭い幅では text-2xl だと1文字だけ次の行に落ちるため、1段階小さくして1行に収める。
+      text-balance は長音符が行頭に来るので使わない。実測値と経緯は #158 %>
   <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">
     <%= t(".heading") %>
   </h1>

--- a/app/views/taste_profiles/show.html.erb
+++ b/app/views/taste_profiles/show.html.erb
@@ -12,7 +12,10 @@
 
 
 <div class="max-w-3xl mx-auto py-10 px-4">
-  <h1 class="text-2xl font-semibold mb-6 text-center">
+  <%# 390px では text-2xl だと 335px 必要で、使える幅 326px に収まらず「果」だけが
+      次の行に落ちる。狭い幅でだけ1段階小さくして1行に収める（#158）。
+      text-balance も試したが、「コーヒ / ー」と長音符が行頭に来るため採らなかった %>
+  <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">
     <%= t(".heading") %>
   </h1>
 

--- a/app/views/trial_results/show.html.erb
+++ b/app/views/trial_results/show.html.erb
@@ -9,7 +9,10 @@
 <% content_for :ogp_description, @description %>
 
 <div class="max-w-3xl mx-auto py-10 px-4">
-  <h1 class="text-2xl font-semibold mb-6 text-center">
+  <%# 390px では text-2xl だと 335px 必要で、使える幅 326px に収まらず「果」だけが
+      次の行に落ちる。狭い幅でだけ1段階小さくして1行に収める（#158）。
+      text-balance も試したが、「コーヒ / ー」と長音符が行頭に来るため採らなかった %>
+  <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">
     <%= t("taste_profiles.show.heading") %>
   </h1>
 

--- a/app/views/trial_results/show.html.erb
+++ b/app/views/trial_results/show.html.erb
@@ -9,9 +9,8 @@
 <% content_for :ogp_description, @description %>
 
 <div class="max-w-3xl mx-auto py-10 px-4">
-  <%# 390px では text-2xl だと 335px 必要で、使える幅 326px に収まらず「果」だけが
-      次の行に落ちる。狭い幅でだけ1段階小さくして1行に収める（#158）。
-      text-balance も試したが、「コーヒ / ー」と長音符が行頭に来るため採らなかった %>
+  <%# 狭い幅では text-2xl だと1文字だけ次の行に落ちるため、1段階小さくして1行に収める。
+      text-balance は長音符が行頭に来るので使わない。実測値と経緯は #158 %>
   <h1 class="text-xl sm:text-2xl font-semibold mb-6 text-center">
     <%= t("taste_profiles.show.heading") %>
   </h1>


### PR DESCRIPTION
診断結果の見出しが、スマートフォン幅で最後の1文字だけ折り返す問題を直す（#158）。

```
修正前                          修正後
あなたのコーヒー味覚診断結      あなたのコーヒー味覚診断結果
果
```

## 原因

390px では見出しの使える幅が **326px** なのに対し、`text-2xl`（24px）だと
14文字で **335px** 必要になり、9px 足りずに「果」だけが次の行に落ちていた。

狭い幅でのみ `text-xl` にして1行に収める。`sm` 以上は従来どおり `text-2xl`。

## `text-balance` を採らなかった理由

最初 `text-balance`（`text-wrap: balance`）を当てた。幅は **168px / 168px** と綺麗に揃うが、
**折り返し位置が「あなたのコーヒ / ー味覚診断結果」となり、長音符が行頭に来る。**

日本語として読みにくく、幅が揃っても改悪になる。`line-break: strict` を併用しても
位置は変わらなかったため、この案は捨てた。

## 実測

ローカルの開発環境に iframe を埋めて幅を変え、`Range#getClientRects()` で行ごとの幅を測った。

| 幅 | フォント | 行数 | 各行の幅 |
| --- | --- | --- | --- |
| 320px | 20px | 2 | 239 / 40 |
| **375px** | 20px | **1** | 279 |
| **390px** | 20px | **1** | 279 |
| **414px** | 20px | **1** | 279 |
| 640px | 24px | 1 | 335 |
| 768px | 24px | 1 | 335 |

いずれの幅でも横スクロールは発生しない。

**320px では2行のままだが、1文字ではなく2文字になり不自然さは減る。**
この幅の端末は現行世代に無いため（iPhone SE 第2世代以降は 375px）、
追加のブレークポイントは入れていない。

## 対象

同じ見出しを2つのビューが共有しているため、両方に同じ変更を入れた。

- `app/views/taste_profiles/show.html.erb`（ログイン後の診断結果）
- `app/views/trial_results/show.html.erb`（未ログインの試し診断結果。**X でシェアされる画面**）

文言（`config/locales/views/ja.yml`）には手を入れていない。
`<br>` を埋め込むと、幅が変わったときに不自然な位置で切れるため。

## 検証

- 上表のとおり、幅を変えて行数と各行の幅を実測
- 390px で描画を目視（1行になり、横スクロールなし）
- `bundle exec rspec` 300 examples, 0 failures / `bin/rubocop` no offenses

`taste_profiles/show` はログインが必要なため、実測は `trial_results/show` で行った。
両ビューの見出しの markup は同一。

---

## レビューを受けての対応

サブエージェントによるレビューを1回実施した（重大な問題は0件）。改善提案4件の扱いは次のとおり。

### 取り込んだもの

**同じコメントが2ファイルに重複している** → コメントを2行に縮めた（`08f8ef8`）。

ピクセル値をコードのコメントに書くと、padding や文言が変わった時点で嘘になる。
陳腐化しない2点（なぜ小さくするのか / なぜ `text-balance` を使わないのか）だけをコメントに残し、
実測値は #158 に置いた。

### 取り込まなかったもの

**1. ブレークポイントを `sm`（640px）ではなく `min-[400px]` にする**

「`text-2xl` は 400px から1行に収まるので、414px・430px の端末まで巻き添えで小さくするのは
過剰」という指摘。**採らない。余白が 1px 以下しかなく、この PR が直したのと同じ壊れ方をするため。**

見出しの必要幅を、フォントを変えながらフォントサイズ別に実測した。

| フォント | 必要幅 |
| --- | --- |
| Hiragino Sans（iOS / macOS） | **13.970em** |
| Noto Sans CJK JP | 13.970em |
| Yu Gothic | **14.000em** |

全角14文字なのでほぼ 1文字 = 1em になり、**フォントを変えてもほとんど動かない**。
つまり必要幅は `フォントサイズ × 約14`、使える幅は `画面幅 − 64`（`main` と内側の `div` の `px-4`）で決まる。

| 画面幅 | 使える幅 | `text-2xl` の必要幅 | 余白 |
| --- | --- | --- | --- |
| **400px** | 336px | 335.3 〜 **336.0px** | **0 〜 0.7px** |
| 402px | 338px | 同上 | 2px |
| 414px | 350px | 同上 | 14px |

400px は Yu Gothic だと**余白ゼロ**（336 対 336）。加えてこの値は文言の長さに直結するため、
`ja.yml` の見出しが1文字増えただけでブレークポイントが破綻する。
「画面幅 400px」という数字は実際には「見出しが14文字であること」に依存しており、
その依存関係がコード上のどこにも現れない。

余白を確保できる位置（412px 以上）まで下げれば安全だが、得られるのは
412px 以上の端末で見出しが 20px → 24px に戻ることだけで、割に合わない。
`text-xl`（20px）でも読みにくくはなく、`mypage/show` が既に `text-xl sm:text-2xl` を使っているため
`sm` のままの方が揃う。

**2. 診断フロー内で見出しサイズが揃わなくなる**

`/trial_diagnosis`（`taste_diagnoses/new`）の見出しは `text-2xl` のままなので、
診断画面 24px → 結果画面 20px と1段階変わる、という指摘。事実だが **#158 のスコープ外**。

アプリ全体でも `text-2xl` と `text-xl sm:text-2xl` の2系統が混在している。
折り返しが起きる見出しだけ後者にしている現状は説明はつくが、方針として決まってはいない。
揃えるなら別 Issue が適切。

**3. 320px はブラウザのズームでも到達する**

到達しても2行になるだけで横スクロールは出ないため、対応不要という判断は変えない。

### レビューで確認が取れたもの

- この見出しを使うビューは2つで全部（`grep` で確認済み。変更漏れなし）
- 未ログインで到達できる全ページの `h1` を 390px で測定し、折り返している見出しは他に無い
- 本文に書いた 326px / 335px / `text-balance` の挙動は、いずれも再現した
