### PR TITLE
fix: 試し診断の引き継ぎの不具合を直し、フロー全体に spec を入れる (#151)

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -65,31 +65,39 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
   def after_sign_up_path_for(resource)
     raw = cookies.encrypted[:trial_answers]
+    return new_taste_diagnosis_path if raw.blank?
 
-    if raw.present?
-      begin
-        parsed = JSON.parse(raw) # {"chocolate"=>"...", ...}
-        answers = TasteDiagnosisLogic.extract_answers(ActionController::Parameters.new(answers: parsed)[:answers])
-
-        if answers.present?
-          result = TasteDiagnosisLogic.diagnose(answers)
-          TasteDiagnosisLogic.apply_result_to_user!(user: resource, result: result)
-        end
-      rescue JSON::ParserError
-        # 何もしない（trial無し扱いで通常フローへ）
-      ensure
-        cookies.delete(:trial_answers)
-      end
-
-      # ★ trialあり：診断済みとしてマイページへ
-      return mypage_path
-    end
-
-    # ★ trialなし：従来どおり診断へ
-    new_taste_diagnosis_path
+    # 引き継げたときだけ「診断済み」としてマイページへ送る。
+    # 失敗したのにマイページへ送ると、TasteProfile が無いまま診断済み前提の画面に立たされる（#151）
+    apply_trial_answers(resource, raw) ? mypage_path : new_taste_diagnosis_path
   end
 
   def after_inactive_sign_up_path_for(resource)
     root_path
+  end
+
+  private
+
+  # 試し診断の回答を診断結果として保存する。引き継げたら true。
+  #
+  # 登録そのものは成功しているため、引き継ぎの失敗で登録を巻き戻さない。
+  # Cookie は成否によらず捨てる。壊れた Cookie を残しても次に読んだときまた失敗するだけのため。
+  def apply_trial_answers(user, raw)
+    parsed = JSON.parse(raw)
+    return false unless parsed.is_a?(Hash)
+
+    answers = TasteDiagnosisLogic.extract_answers(
+      ActionController::Parameters.new(answers: parsed)[:answers]
+    )
+    return false if answers.blank?
+
+    result = TasteDiagnosisLogic.diagnose(answers)
+    TasteDiagnosisLogic.apply_result_to_user!(user: user, result: result)
+    true
+  rescue JSON::ParserError, ActiveRecord::RecordInvalid => e
+    Rails.logger.warn("試し診断の引き継ぎに失敗しました: #{e.class}")
+    false
+  ensure
+    cookies.delete(:trial_answers)
   end
 end

--- a/spec/requests/trial_diagnoses_spec.rb
+++ b/spec/requests/trial_diagnoses_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe "TrialDiagnoses", type: :request do
+  # 深煎り寄りになる回答（taste_diagnoses_spec と同じ組み合わせ）
+  let(:valid_answers) do
+    {
+      chocolate: "dark_chocolate",
+      cake: "mont_blanc",
+      dressing: "japanese_dressing",
+      amount: "little",
+      dislike: "too_sour"
+    }
+  end
+
+  # 暗号化 Cookie は Rack::Test の cookie jar からは平文で読めないため、
+  # 直近のリクエストの鍵で復号する。
+  def decrypted_trial_answers
+    ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash).encrypted[:trial_answers]
+  end
+
+  def set_cookie_header
+    Array(response.headers["set-cookie"] || response.headers["Set-Cookie"]).join("\n")
+  end
+
+  describe "GET /trial_diagnosis" do
+    it "未ログインでも診断ページが表示されること" do
+      get trial_diagnosis_path
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("コーヒー味覚診断")
+    end
+  end
+
+  describe "POST /trial_diagnosis" do
+    context "全ての質問に回答した場合" do
+      it "回答が暗号化Cookieに保存されること" do
+        post trial_diagnosis_path, params: { answers: valid_answers }
+
+        expect(JSON.parse(decrypted_trial_answers)).to eq(valid_answers.stringify_keys)
+      end
+
+      it "Cookieの有効期限が1時間であること" do
+        post trial_diagnosis_path, params: { answers: valid_answers }
+
+        expires = set_cookie_header[/trial_answers=[^;]+;[^\n]*?expires=([^;]+)/i, 1]
+        expect(expires).to be_present
+        expect(Time.parse(expires)).to be_within(5.minutes).of(1.hour.from_now)
+      end
+
+      it "回答に応じた試し診断の結果ページにリダイレクトされること" do
+        post trial_diagnosis_path, params: { answers: valid_answers }
+
+        expect(response).to redirect_to(trial_result_path(type: "medium_dark"))
+      end
+
+      it "未ログインのためTasteProfileは作られないこと" do
+        expect {
+          post trial_diagnosis_path, params: { answers: valid_answers }
+        }.not_to change(TasteProfile, :count)
+      end
+    end
+
+    context "未回答の質問がある場合" do
+      it "422になり、診断ページが再表示されること" do
+        post trial_diagnosis_path, params: { answers: valid_answers.except(:dislike) }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("コーヒー味覚診断")
+      end
+
+      it "Cookieが書かれないこと" do
+        post trial_diagnosis_path, params: { answers: valid_answers.except(:dislike) }
+
+        expect(cookies[:trial_answers]).to be_blank
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -44,6 +44,133 @@ RSpec.describe "Users", type: :request do
     end
   end
 
+  # 未ログインの試し診断 → 暗号化Cookie → 登録時に TasteProfile へ反映、という集客導線（#151）。
+  # 壊れても新規ユーザーだけが診断結果を失うため、既存ユーザーの動作確認では気づけない。
+  describe "試し診断の結果の引き継ぎ" do
+    # 深煎り寄りになる回答（taste_diagnoses_spec と同じ組み合わせ）
+    let(:valid_answers) do
+      {
+        chocolate: "dark_chocolate",
+        cake: "mont_blanc",
+        dressing: "japanese_dressing",
+        amount: "little",
+        dislike: "too_sour"
+      }
+    end
+
+    let(:registration_params) do
+      {
+        user: {
+          name: "テストユーザー",
+          email: "trial@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      }
+    end
+
+    # 壊れたCookieは正規の経路では作れないため、暗号化だけ本物と同じ方法で行って直接置く
+    def set_encrypted_trial_cookie(raw_value)
+      get root_path
+      jar = ActionDispatch::Cookies::CookieJar.build(request, {})
+      jar.encrypted[:trial_answers] = raw_value
+      cookies[:trial_answers] = jar[:trial_answers]
+    end
+
+    context "試し診断を終えてから登録した場合" do
+      before { post trial_diagnosis_path, params: { answers: valid_answers } }
+
+      it "診断結果がTasteProfileに引き継がれること" do
+        expect {
+          post user_registration_path, params: registration_params
+        }.to change(TasteProfile, :count).by(1)
+
+        profile = User.find_by(email: "trial@example.com").taste_profile
+        expect(profile.preferred_roast).to eq("medium_dark")
+        expect(profile.bitterness_score).to eq(10)
+        expect(profile.acidity_score).to eq(5)
+      end
+
+      it "マイページにリダイレクトされること" do
+        post user_registration_path, params: registration_params
+        expect(response).to redirect_to(mypage_path)
+      end
+
+      it "引き継いだCookieが削除されること" do
+        post user_registration_path, params: registration_params
+        expect(cookies[:trial_answers]).to be_blank
+      end
+    end
+
+    # 引き継げなかったのだから、診断済みを前提とするマイページではなく診断ページへ送る
+    shared_examples "診断ページへ送られる" do
+      it "TasteProfileが作られないこと" do
+        expect {
+          post user_registration_path, params: registration_params
+        }.not_to change(TasteProfile, :count)
+      end
+
+      it "診断ページにリダイレクトされること" do
+        post user_registration_path, params: registration_params
+        expect(response).to redirect_to(new_taste_diagnosis_path)
+      end
+
+      it "ユーザー自体は作られること" do
+        expect {
+          post user_registration_path, params: registration_params
+        }.to change(User, :count).by(1)
+      end
+
+      it "Cookieが削除されること" do
+        post user_registration_path, params: registration_params
+        expect(cookies[:trial_answers]).to be_blank
+      end
+    end
+
+    context "Cookieが壊れている場合" do
+      context "JSONとして壊れている場合" do
+        before { set_encrypted_trial_cookie("{壊れたJSON") }
+        include_examples "診断ページへ送られる"
+      end
+
+      context "必須の回答が欠けている場合" do
+        before { set_encrypted_trial_cookie(valid_answers.except(:dislike).to_json) }
+        include_examples "診断ページへ送られる"
+      end
+
+      context "JSONだがオブジェクトではない場合" do
+        before { set_encrypted_trial_cookie("[1, 2, 3]") }
+        include_examples "診断ページへ送られる"
+      end
+    end
+
+    context "診断結果の保存に失敗した場合" do
+      before do
+        post trial_diagnosis_path, params: { answers: valid_answers }
+        allow(TasteDiagnosisLogic).to receive(:apply_result_to_user!)
+          .and_raise(ActiveRecord::RecordInvalid.new(TasteProfile.new))
+      end
+
+      it "例外が外に出ず、診断ページにリダイレクトされること" do
+        post user_registration_path, params: registration_params
+        expect(response).to redirect_to(new_taste_diagnosis_path)
+      end
+
+      it "ユーザー自体は作られること" do
+        expect {
+          post user_registration_path, params: registration_params
+        }.to change(User, :count).by(1)
+      end
+    end
+
+    context "試し診断をしていない場合" do
+      it "診断ページにリダイレクトされること" do
+        post user_registration_path, params: registration_params
+        expect(response).to redirect_to(new_taste_diagnosis_path)
+      end
+    end
+  end
+
   describe "ログイン" do
     let(:user) { create(:user) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
-    mocks.syntax = :expec
+    mocks.syntax = :expect
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
未ログインで診断 → 暗号化Cookie → 登録時に `TasteProfile` へ反映、という集客導線に
spec が1件も無かった（#151）。spec を入れる過程で、テスト不足では説明できない
実装の不具合が **3件**見つかったため、あわせて直す。

## 見つかった不具合

いずれも**新規ユーザーだけが踏む**経路にあり、既存ユーザーの動作確認では気づけない。

### ① 引き継ぎに失敗してもマイページへ送っていた

`return mypage_path` が `begin/rescue` の外にあり、次のどの経路でも同じ場所へ行っていた。

- `JSON::ParserError` で rescue された
- `extract_answers` が `nil` を返した（必須キーの欠落）
- 正常に `TasteProfile` が作られた

前の2つでは **`TasteProfile` が無いまま「診断済み」前提のマイページに立たされる。**

引き継ぎの成否を返す `apply_trial_answers` に切り出し、**成功したときだけ**マイページへ送る。
失敗時は試し診断をしていない場合と同じく診断ページへ送る。

### ② `ActiveRecord::RecordInvalid` が rescue されていなかった

`apply_result_to_user!` は `save!` を使うため検証失敗で例外を投げる。
`taste_diagnoses_controller.rb:25` には同じ rescue があるのに、こちらには無かった。

**登録とサインインが完了した直後に 422 のエラーページが出る**（500 ではない。
Rails が `RecordInvalid` を 422 にマップするため）。アカウントは作られ、
ログインも済んでいるのに画面はエラー、という分かりにくい状態になる。

### ③ オブジェクト以外の JSON で `NoMethodError` になっていた

Cookie の中身が配列などだと `extract_answers` が `Array#permit` を呼んで落ちる。
暗号化Cookieなので外部から仕込むことはできないが、`JSON.parse` の結果を
Hash と決めつけている点は塞いでおく。`parsed.is_a?(Hash)` で弾く。

## spec

3段すべてを request spec で固定した。

| 段 | 追加した spec |
| --- | --- |
| Cookie に書く | `spec/requests/trial_diagnoses_spec.rb`（新規・7 examples） |
| Cookie を読んで反映する | `spec/requests/users_spec.rb` に「試し診断の結果の引き継ぎ」（18 examples） |

主な観点。

- 回答が暗号化Cookieに入ること／**有効期限が1時間**であること
- 未回答があれば 422 になり、**Cookie は書かれない**こと
- 引き継ぎ成功時: `TasteProfile` の `preferred_roast` とスコアが診断結果と一致し、
  マイページへ行き、Cookie が削除されること
- 引き継ぎ失敗時（不正JSON / キー欠落 / オブジェクト以外 / 保存失敗）:
  `TasteProfile` が作られず、**診断ページ**へ行き、ユーザー自体は作られ、Cookie が削除されること

暗号化Cookie は Rack::Test の cookie jar から平文で読めないため、直近のリクエストの鍵で
`ActionDispatch::Cookies::CookieJar` を組み立てて読み書きしている。
壊れたCookieは正規の経路では作れないため、暗号化だけ本物と同じ方法で行って直接置いた。

## スイート設定の修正（副産物）

`spec/spec_helper.rb` に **`mocks.syntax = :expec`**（`:expect` の綴り誤り）があり、
`:should` も `:expect` も有効にならず、**スイート全体でスタブが使えない状態**だった。
`allow(...)` が `NoMethodError` になる。

これまで誰もスタブを使っていなかったため表面化していなかったが、②の例外経路を
検証するのに必要なため直した。

## 検証

- `bundle exec rspec` **325 examples, 0 failures**（300 → 325）
- `bin/rubocop` no offenses
- **変異テスト**: 実装を6通りに壊して、spec が落ちることを確認した

| 壊し方 | 落ちた example |
| --- | --- |
| 失敗しても常にマイページへ送る | 4 |
| `is_a?(Hash)` の判定を外す | 4 |
| `RecordInvalid` を rescue しない | 1 |
| Cookie の削除をやめる | 4 |
| Cookie の有効期限を3時間にする | 1 |
| 未回答でも Cookie を書く | 2 |

ブラウザでの手動確認は行っていない。このフローの確認には新規登録（パスワード入力）が
必要なため、request spec での検証に留めている。

## スコープ外

`TasteDiagnosisLogic` 自体のユニット spec は今回も入れていない（#151 に明記のとおり）。
5問→スコア→焙煎度の判定は、今回追加分を含めても「深煎り寄りの回答」1ケースしか通っていない。